### PR TITLE
Let's think about scaffolding

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/VKmer.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/VKmer.java
@@ -752,5 +752,16 @@ public class VKmer extends BinaryComparable implements Serializable, WritableCom
         }
         return c.compare(getBlockBytes(), getBlockOffset(), getLength(), other.getBytes(), 0, other.getLength());
     }
+    
+    /**
+     * create a new VKmer from the given id. The VKmer will have a fixed length of 16 letters and
+     * kmer letters equivalent to the given int id's bits
+     */
+    public static VKmer getIdAsVKmer(int id) {
+        byte[] storage = new byte[4 + 4];  // 4 for VKmer header, 4 for int value
+        Marshal.putInt(16, storage, 0);  // write length header
+        Marshal.putInt(id, storage, 4);  // write id
+        return new VKmer(storage, 0);
+    }
 
 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/DeBruijnGraphCleanVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/DeBruijnGraphCleanVertex.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.genomix.pregelix.operator;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -39,11 +40,11 @@ public abstract class DeBruijnGraphCleanVertex<V extends VertexValueWritable, M 
     public static int maxIteration = -1;
 
     public static Object lock = new Object();
-    public static boolean fakeVertexExist = false;
+    public static boolean tempPartitionExists = false;
     public static VKmer fakeVertex = new VKmer();
 
-    public EDGETYPE[][] validPathsTable = new EDGETYPE[][] { { EDGETYPE.RF, EDGETYPE.FF }, { EDGETYPE.RF, EDGETYPE.FR },
-            { EDGETYPE.RR, EDGETYPE.FF }, { EDGETYPE.RR, EDGETYPE.FR } };
+    public EDGETYPE[][] validPathsTable = new EDGETYPE[][] { { EDGETYPE.RF, EDGETYPE.FF },
+            { EDGETYPE.RF, EDGETYPE.FR }, { EDGETYPE.RR, EDGETYPE.FF }, { EDGETYPE.RR, EDGETYPE.FR } };
 
     protected M outgoingMsg = null;
     protected VertexValueWritable tmpValue = new VertexValueWritable();
@@ -111,10 +112,10 @@ public abstract class DeBruijnGraphCleanVertex<V extends VertexValueWritable, M 
      * add fake vertex
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void addFakeVertex(String fakeKmer) {
+    public void addMapPartitionVertices(String fakeKmer) {
         synchronized (lock) {
             fakeVertex.setFromStringBytes(1, fakeKmer.getBytes(), 0);
-            if (!fakeVertexExist) {
+            if (!tempPartitionExists) {
                 //add a fake vertex
                 Vertex vertex = (Vertex) BspUtils.createVertex(getContext().getConfiguration());
 
@@ -125,7 +126,7 @@ public abstract class DeBruijnGraphCleanVertex<V extends VertexValueWritable, M 
                 vertex.setVertexValue(vertexValue);
 
                 addVertex(fakeVertex, vertex);
-                fakeVertexExist = true;
+                tempPartitionExists = true;
             }
         }
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicMapReduceVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicMapReduceVertex.java
@@ -84,7 +84,7 @@ public class BasicMapReduceVertex<V extends VertexValueWritable, M extends PathM
         reduceKeyByInternalKmer(kmerMapper);
 
         //delele self(fake vertex)
-        fakeVertexExist = false;
+        tempPartitionExists = false;
         deleteVertex(fakeVertex);
     }
 
@@ -92,7 +92,7 @@ public class BasicMapReduceVertex<V extends VertexValueWritable, M extends PathM
     public void compute(Iterator<M> msgIterator) {
         initVertex();
         if (getSuperstep() == 1) {
-            addFakeVertex("A");
+            addMapPartitionVertices("A");
         } else if (getSuperstep() == 2) {
             sendMsgToFakeVertex();
         } else if (getSuperstep() == 3) {

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
@@ -4,6 +4,9 @@ import java.util.Iterator;
 
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 
 import edu.uci.ics.genomix.pregelix.io.PathAndEdgeTypeList;
 import edu.uci.ics.genomix.pregelix.io.ScaffoldingVertexValueWritable;
@@ -22,6 +25,7 @@ import edu.uci.ics.genomix.type.ReadHeadSet;
 import edu.uci.ics.genomix.type.VKmer;
 import edu.uci.ics.genomix.type.VKmerList;
 import edu.uci.ics.pregelix.api.graph.Vertex;
+import edu.uci.ics.pregelix.api.io.WritableSizable;
 import edu.uci.ics.pregelix.api.util.BspUtils;
 
 public class BasicBFSTraverseVertex extends
@@ -43,7 +47,7 @@ public class BasicBFSTraverseVertex extends
             fakeVertex.setFromStringBytes(1, fakeKmer.getBytes(), 0);
             if (!fakeVertexExist) {
                 // add a fake vertex
-                Vertex vertex = (Vertex) BspUtils.createVertex(getContext().getConfiguration());
+                Vertex<VKmer, ScaffoldingVertexValueWritable, NullWritable, BFSTraverseMessage> vertex = BspUtils.createVertex(getContext().getConfiguration());
 
                 ScaffoldingVertexValueWritable vertexValue = new ScaffoldingVertexValueWritable();
                 vertexValue.setFakeVertex(true);

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
@@ -5,8 +5,6 @@ import java.util.Iterator;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableComparable;
 
 import edu.uci.ics.genomix.pregelix.io.PathAndEdgeTypeList;
 import edu.uci.ics.genomix.pregelix.io.ScaffoldingVertexValueWritable;
@@ -25,11 +23,13 @@ import edu.uci.ics.genomix.type.ReadHeadSet;
 import edu.uci.ics.genomix.type.VKmer;
 import edu.uci.ics.genomix.type.VKmerList;
 import edu.uci.ics.pregelix.api.graph.Vertex;
-import edu.uci.ics.pregelix.api.io.WritableSizable;
 import edu.uci.ics.pregelix.api.util.BspUtils;
 
 public class BasicBFSTraverseVertex extends
         DeBruijnGraphCleanVertex<ScaffoldingVertexValueWritable, BFSTraverseMessage> {
+
+    public static final int SCAFFOLDING_NUMBER_OF_PARTITIONS = 50000;
+    protected static VKmer[] tempPartitionIds = new VKmer[SCAFFOLDING_NUMBER_OF_PARTITIONS];
 
     public enum UPDATELENGTH_TYPE {
         SRC_OFFSET,
@@ -42,22 +42,29 @@ public class BasicBFSTraverseVertex extends
         CONTINUE_SEARCH;
     }
 
-    public void addFakeVertex(String fakeKmer) {
-        synchronized (lock) {
-            fakeVertex.setFromStringBytes(1, fakeKmer.getBytes(), 0);
-            if (!fakeVertexExist) {
-                // add a fake vertex
-                Vertex<VKmer, ScaffoldingVertexValueWritable, NullWritable, BFSTraverseMessage> vertex = BspUtils.createVertex(getContext().getConfiguration());
+    public synchronized void addTempPartitionVertices() {
+        // TODO push this logic up into DeBruijn graph clean
+        if (!tempPartitionExists) {
+            for (int i = 0; i < SCAFFOLDING_NUMBER_OF_PARTITIONS; i++) {
+                // TODO it might make sense to only create those vertices that will be used here...
+                tempPartitionIds[i] = VKmer.getIdAsVKmer(i); // FIXME this may collide with existing kmers if the user selects K=16 or shorter
 
-                ScaffoldingVertexValueWritable vertexValue = new ScaffoldingVertexValueWritable();
+                Vertex<VKmer, ScaffoldingVertexValueWritable, NullWritable, BFSTraverseMessage> vertex = BspUtils
+                        .createVertex(getContext().getConfiguration());
+
+                ScaffoldingVertexValueWritable vertexValue;
+                try {
+                    vertexValue = getVertexValue().getClass().newInstance();
+                } catch (InstantiationException | IllegalAccessException e) {
+                    throw new IllegalStateException("Failed to create a new instance of VertexValue!", e);
+                }
                 vertexValue.setFakeVertex(true);
 
-                vertex.setVertexId(fakeVertex);
+                vertex.setVertexId(tempPartitionIds[i]);
                 vertex.setVertexValue(vertexValue);
-
-                addVertex(fakeVertex, vertex);
-                fakeVertexExist = true;
+                addVertex(tempPartitionIds[i], vertex);
             }
+            tempPartitionExists = true;
         }
     }
 

--- a/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/JobGen/JobGenerator.java
+++ b/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/JobGen/JobGenerator.java
@@ -127,6 +127,7 @@ public class JobGenerator {
     private static void genSymmetryCheckerGraph() throws IOException {
         generateSymmetryCheckerGraphJob("SymmetryCheckerGraph", outputBase + "SymmetryCheckerGraph.xml");
     }
+
     /**
      * Main Function
      */

--- a/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/Test/BFSTraverseVertex.java
+++ b/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/Test/BFSTraverseVertex.java
@@ -154,7 +154,7 @@ public class BFSTraverseVertex extends BasicBFSTraverseVertex {
     public void compute(Iterator<BFSTraverseMessage> msgIterator) {
         if (getSuperstep() == 1) {
             initVertex();
-            addFakeVertex("A");
+            addMapPartitionVertices("A");
             voteToHalt();
         } else if (getSuperstep() == 2) {
             // for test, read srcNode and destNode from jobconf


### PR DESCRIPTION
The important commit is 90266bb, where instead of one vertex handling the scaffold group-by, there are up to 50,000.  The hash spread for the readids is poor: uniform spread would have 5k of data going to each node; this commit fails on the dsm data because one node is receiving 132k of scaffold map messages.  I know I can improve the hash code but that will only get us so far.

The group-by is a filtering step, removing some searches that are bound to fail (both endpoints must be "unique"). There's no other reason to group (the search _could_ proceed without knowing the destination kmer at all).

It's been suggested that we try a group-by using hyracks.  That would certainly be more performant but there's certainly a lot of dev time that would need to be spent on it.  A map-reduce job would be very simple to implement. But these would only help with the filtering and not the subsequent BFS.

Any other thoughts?
