### PR TITLE
fix for connection refused errors: go back to `getip.sh`

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/DriverUtils.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/DriverUtils.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -46,8 +45,18 @@ public class DriverUtils {
      * Get the IP address of the master node using the bin/getip.sh script
      */
     public static String getIP(String hostName) throws IOException, InterruptedException {
-        InetAddress address = InetAddress.getByName(hostName);
-        return address.getHostAddress();
+        String getIPCmd = "ssh -n " + hostName + " \"" + System.getProperty("app.home", ".") + File.separator + "bin"
+                + File.separator + "getip.sh\"";
+        Process p = Runtime.getRuntime().exec(getIPCmd);
+        p.waitFor(); // wait for ssh 
+        String stdout = IOUtils.toString(p.getInputStream()).trim();
+        if (p.exitValue() != 0)
+            throw new RuntimeException("Failed to get the ip address of the master node! Script returned exit code: "
+                    + p.exitValue() + "\nstdout: " + stdout + "\nstderr: " + IOUtils.toString(p.getErrorStream()));
+        return stdout;
+        //      InetAddress address = InetAddress.getByName(hostName);
+        //      System.out.println("inetAddress for " + hostName + address.getHostAddress());
+        //      return address.getHostAddress();
     }
 
     /**


### PR DESCRIPTION
@JavierJia 

As I mentioned on https://github.com/uci-cbcl/genomix/commit/0f31651729af55d028709904b58080768f5f4607#diff-fd9a88e53b0fd0f4e9040cf3157230eeR50 is seems there's a regression using the java inet lookup.  I played with it briefly but couldn't find a solution where the two agreed about the correct IP.

Since the `startCC.sh` and `startNC.sh` scripts use `getIP.sh`, I'm opting to keep it, at least until we can figure out a more general fix.
