### PR TITLE
STATS job cleanup and fixes

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GenomixClusterManager.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GenomixClusterManager.java
@@ -344,16 +344,15 @@ public class GenomixClusterManager {
     }
 
     private void removeClusterShutdownHook(final ClusterType clusterType) {
-        if (!shutdownHooks.containsKey(clusterType))
-            // throw new
-            // IllegalArgumentException("There is no shutdown hook for " +
-            // clusterType + "!");
+        if (!shutdownHooks.containsKey(clusterType)) {
             return; // ignore-- we are cleaning up after a previous run
+        }
         try {
             Runtime.getRuntime().removeShutdownHook(shutdownHooks.get(clusterType));
         } catch (IllegalStateException e) {
             // ignore: we must already be shutting down
         }
+        shutdownHooks.remove(clusterType);
     }
 
     public static void copyLocalToHDFS(JobConf conf, String localDir, String destDir) throws IOException {

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -147,6 +147,8 @@ public class GenomixDriver {
             case STATS:
                 flushPendingJobs(conf);
                 manager.startCluster(ClusterType.HADOOP);
+                curOutput = prevOutput + "-STATS";
+                stepNum--;
                 Counters counters = GraphStatistics.run(prevOutput, curOutput, conf);
                 GraphStatistics.saveGraphStats(curOutput, counters, conf);
                 GraphStatistics.drawStatistics(curOutput, counters, conf);

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -149,7 +149,7 @@ public class GenomixDriver {
                 manager.startCluster(ClusterType.HADOOP);
                 Counters counters = GraphStatistics.run(prevOutput, curOutput, conf);
                 GraphStatistics.saveGraphStats(curOutput, counters, conf);
-                GraphStatistics.drawStatistics(curOutput, counters);
+                GraphStatistics.drawStatistics(curOutput, counters, conf);
                 manager.stopCluster(ClusterType.HADOOP);
                 curOutput = prevOutput; // use previous job's output
                 break;

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -146,9 +146,11 @@ public class GenomixDriver {
                 break;
             case STATS:
                 flushPendingJobs(conf);
+                manager.startCluster(ClusterType.HADOOP);
                 Counters counters = GraphStatistics.run(prevOutput, curOutput, conf);
                 GraphStatistics.saveGraphStats(curOutput, counters, conf);
                 GraphStatistics.drawStatistics(curOutput, counters);
+                manager.stopCluster(ClusterType.HADOOP);
                 curOutput = prevOutput; // use previous job's output
                 break;
         }

--- a/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/graph/GraphStatistics.java
+++ b/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/graph/GraphStatistics.java
@@ -48,28 +48,20 @@ import edu.uci.ics.genomix.type.VKmer;
 public class GraphStatistics extends MapReduceBase implements Mapper<VKmer, Node, Text, LongWritable> {
 
     public static final Logger LOG = Logger.getLogger(GraphStatistics.class.getName());
+    private Reporter reporter;
 
     @Override
     public void map(VKmer key, Node value, OutputCollector<Text, LongWritable> output, Reporter reporter)
             throws IOException {
-
-        reporter.getCounter("totals", "nodes").increment(1);
-
-        reporter.getCounter("degree-bins", Integer.toString(value.inDegree() + value.outDegree())).increment(1);
-        reporter.getCounter("totals", "degree").increment(value.inDegree() + value.outDegree());
-
-        int kmerLength = value.getKmerLength() == 0 ? key.getKmerLetterLength() : value.getKmerLength();
-        reporter.getCounter("kmerLength-bins", Integer.toString(kmerLength)).increment(1);
-        reporter.getCounter("totals", "kmerLength").increment(kmerLength);
-
-        reporter.getCounter("coverage-bins", Integer.toString(Math.round(value.getAverageCoverage()))).increment(1);
-        reporter.getCounter("totals", "coverage").increment(Math.round(value.getAverageCoverage()));
-
-        reporter.getCounter("startRead-bins", Integer.toString(Math.round(value.getStartReads().size()))).increment(1);
-        reporter.getCounter("totals", "startRead").increment(Math.round(value.getStartReads().size()));
-
-        reporter.getCounter("endRead-bins", Integer.toString(Math.round(value.getEndReads().size()))).increment(1);
-        reporter.getCounter("totals", "endRead").increment(Math.round(value.getEndReads().size()));
+        this.reporter = reporter;
+        
+        reporter.incrCounter("totals", "nodes", 1);
+        updateStats("degree", value.inDegree() + value.outDegree());
+        updateStats("kmerLength", value.getKmerLength() == 0 ? key.getKmerLetterLength() : value.getKmerLength());
+        updateStats("coverage", Math.round(value.getAverageCoverage()));
+        updateStats("startRead", value.getStartReads().size());
+        updateStats("endRead", value.getEndReads().size());
+        
 
         long totalEdgeReads = 0;
         long totalSelf = 0;
@@ -77,24 +69,36 @@ public class GraphStatistics extends MapReduceBase implements Mapper<VKmer, Node
             for (Entry<VKmer, ReadIdSet> e : value.getEdgeMap(et).entrySet()) {
                 totalEdgeReads += e.getValue().size();
                 if (e.getKey().equals(key)) {
-                    reporter.getCounter("totals", "selfEdge-" + et).increment(1);
+                    reporter.incrCounter("totals", "selfEdge-" + et, 1);
                     totalSelf += 1;
                 }
             }
         }
-        reporter.getCounter("edgeRead-bins", Long.toString(totalEdgeReads)).increment(1);
-        reporter.getCounter("totals", "edgeRead").increment(totalEdgeReads);
-        reporter.getCounter("selfEdge-bins", Long.toString(totalSelf)).increment(1);
-
+        updateStats("edgeRead", totalEdgeReads);
+        
         if (value.isPathNode())
-            reporter.getCounter("totals", "pathNode").increment(1);
+            reporter.incrCounter("totals", "pathNode", 1);
 
         for (DIR d : DIR.values())
             if (value.degree(d) == 0)
-                reporter.getCounter("totals", "tips-" + d).increment(1);
+                reporter.incrCounter("totals", "tips-" + d, 1);
 
         if (value.inDegree() == 0 && value.outDegree() == 0)
-            reporter.getCounter("totals", "tips-BOTH").increment(1);
+            reporter.incrCounter("totals", "tips-BOTH", 1);
+        
+        if ((value.inDegree() == 0 && value.outDegree() != 0)
+                || (value.inDegree() != 0 && value.outDegree() == 0))
+            reporter.incrCounter("totals", "tips-ONE", 1);
+    }
+    
+    private void updateStats(String valueName, long value) {
+        reporter.incrCounter(valueName + "-bins", Long.toString(value), 1);
+        reporter.incrCounter("totals", valueName, value);
+        
+        long prevMax = reporter.getCounter("maximum", valueName).getValue();
+        if (prevMax < value) {
+            reporter.incrCounter("maximum", valueName, value - prevMax); // increment by difference to get to new value (no set function!)
+        }
     }
 
     /**


### PR DESCRIPTION
@JavierJia @anbangx @Elmira88 @Nan-Zhang 

STATS is a pattern that runs a MapReduce job and creates a text file, `stats.txt` with a bunch of hadoop counters in it.  We also draw histograms of several features.

Current stats calculated are histograms, totals, and maximums for:
- # of nodes
- degree
- kmerLength
- coverage
- # of startReads
- # of endReads
- # of readids across all my edges
- # of self-edges (this one may have a bug right now?)
- # of path nodes
- # of tips, broken down by tips-FORWARD, -REVERSE, -BOTH and -ONE

I think it would be nice to have the N50 and family here as well, merging in @Nan-Zhang 's code.
