### PR TITLE
Jianfeng/fix ssh script in startcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
     - openjdk7
 
 install:
+    - ifconfig
     - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
     - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys  # no pw required for ssh'ing locally
     - ssh localhost -o StrictHostKeyChecking=false -n  # allow us to ssh later w/out typing "yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 
 install:
     - ifconfig
+    - ./genomix/genomix-driver/src/main/resources/scripts/getip.sh
     - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
     - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys  # no pw required for ssh'ing locally
     - ssh localhost -o StrictHostKeyChecking=false -n  # allow us to ssh later w/out typing "yes"

--- a/genomix/genomix-driver/src/main/resources/scripts/getip.sh
+++ b/genomix/genomix-driver/src/main/resources/scripts/getip.sh
@@ -16,6 +16,8 @@ LINUX_OS='Linux'
         then
             IPADDR=`ifconfig lo | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
         fi 
+        IS_VALID_IP=`echo $IPADDR | grep -E "([0-9]{1,3}\.{0,1}){4}"`
+        [ "$IS_VALID_IP" ] || IPADDR=`hostname -i`
 #    fi 
 #else
 #        IPADDR=`/sbin/ifconfig en1 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`

--- a/genomix/genomix-driver/src/main/resources/scripts/getip.sh
+++ b/genomix/genomix-driver/src/main/resources/scripts/getip.sh
@@ -4,25 +4,25 @@
 OS_NAME=`uname -a|awk '{print $1}'`
 LINUX_OS='Linux'
 
-if [ $OS_NAME = $LINUX_OS ];
-then
+#if [ $OS_NAME = $LINUX_OS ];
+#then
     #Get IP Address
     #Prefer Infiniband connection
 #    IPADDR=`/sbin/ifconfig ib0 2> /dev/null | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
 #    if [ "$IPADDR" = "" ]
 #    then
-        IPADDR=`/sbin/ifconfig eth0 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
+        IPADDR=`ifconfig eth0 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
         if [ "$IPADDR" = "" ]
         then
-            IPADDR=`/sbin/ifconfig lo | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
+            IPADDR=`ifconfig lo | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
         fi 
 #    fi 
-else
-        IPADDR=`/sbin/ifconfig en1 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
-	if [ "$IPADDR" = "" ]
-        then
-                IPADDR=`/sbin/ifconfig lo0 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
-        fi
-
-fi
+#else
+#        IPADDR=`/sbin/ifconfig en1 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
+#	if [ "$IPADDR" = "" ]
+#        then
+#                IPADDR=`/sbin/ifconfig lo0 | grep "inet " | awk '{print $2}' | cut -f 2 -d ':'`
+#        fi
+#
+#fi
 echo $IPADDR

--- a/genomix/genomix-driver/src/main/resources/scripts/startDebugNc.sh
+++ b/genomix/genomix-driver/src/main/resources/scripts/startDebugNc.sh
@@ -10,7 +10,7 @@ cd "$GENOMIX_HOME"
 
 #Get the IP address of the cc
 CCHOST_NAME=`cat conf/master`
-CCHOST=`ssh ${CCHOST_NAME} "cd ${GENOMIX_HOME}; bin/getip.sh"`
+CCHOST=`ssh ${CCHOST_NAME} 'bash -s' < ${GENOMIX_HOME}/bin/getip.sh`
 
 #Import cluster properties
 . conf/cluster.properties

--- a/genomix/genomix-driver/src/main/resources/scripts/startcc.sh
+++ b/genomix/genomix-driver/src/main/resources/scripts/startcc.sh
@@ -15,7 +15,7 @@ fi
 . conf/cluster.properties
 #Get the IP address of the cc
 CCHOST_NAME=`cat conf/master`
-CCHOST=`ssh -n ${CCHOST_NAME} "${GENOMIX_HOME}/bin/getip.sh"`
+CCHOST=`ssh ${CCHOST_NAME} 'bash -s' < ${GENOMIX_HOME}/bin/getip.sh`
 
 #Remove the temp dir
 #rm -rf $CCTMP_DIR

--- a/genomix/genomix-driver/src/main/resources/scripts/startnc.sh
+++ b/genomix/genomix-driver/src/main/resources/scripts/startnc.sh
@@ -10,7 +10,7 @@ cd "$GENOMIX_HOME"
 MY_NAME=`hostname`
 #Get the IP address of the cc
 CCHOST_NAME=`cat conf/master`
-CCHOST=`ssh ${CCHOST_NAME} "cd \"${GENOMIX_HOME}\"; bin/getip.sh"`
+CCHOST=`ssh ${CCHOST_NAME} 'bash -s' < ${GENOMIX_HOME}/bin/getip.sh`
 
 #Import cluster properties
 . conf/cluster.properties


### PR DESCRIPTION
The real problem of getip.sh is that it return a `stdout: slave: localhost  23480` , that is really weird.
I add a default cmd to give the result of `hostname -i` if the stdout result is invalide.

It worked in this build : https://travis-ci.org/uci-cbcl/genomix/builds/13068366
