### PR TITLE
Travis-CI improvements: cache .m2 and apt status; separate unit tests & pipeline tests; test -runLocal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+# configuration
 language: java
+cache:
+    - apt
+    - $HOME/.m2
 
+# build matrix
 jdk:
     - oraclejdk7
     - openjdk7
+env:
+    - UNIT_TESTS=true PIPELINE_TESTS=false RUN_LOCAL=""
+    - UNIT_TESTS=false PIPELINE_TESTS=true RUN_LOCAL=""
+    - UNIT_TESTS=false PIPELINE_TESTS=true RUN_LOCAL="-runLocal"
 
+# run steps
 install:
     - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
     - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys  # no pw required for ssh'ing locally
@@ -17,15 +27,4 @@ before_script:
     - cd ../..
 script:
     - cd genomix
-    - mvn package -q -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/logging.properties
-    - ls -t */target/surefire-reports/*.txt | xargs tail -n +1  # show test reports in the order they ran
-    - cd genomix-driver/target/genomix-driver-0.2.10-SNAPSHOT
-
-    # simplified pipeline
-    - bin/genomix -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/
-
-    # default pipeline
-    - bin/genomix -kmerLength 55 -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/  
-
-    # pipeline that repeats steps
-    - bin/genomix -kmerLength 55 -pipelineOrder BUILD_HADOOP,LOW_COVERAGE,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/
+    - ./run_tests.sh

--- a/genomix/run_tests.sh
+++ b/genomix/run_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ -z "$UNIT_TESTS" ]; then UNIT_TESTS=true; fi
+if [ -z "$PIPELINE_TESTS" ]; then PIPELINE_TESTS=true; fi
+if [ -z "$RUN_LOCAL" ]; then RUN_LOCAL=""; fi
+
+echo "UNIT_TESTS: $UNIT_TESTS"
+echo "PIPELINE_TESTS: $PIPELINE_TESTS"
+echo "RUN_LOCAL: $RUN_LOCAL"
+
+EXIT_CODE=0
+
+if [ "$UNIT_TESTS" == "true" ]; then 
+    mvn package -q -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/worker.logging.properties
+    CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE  # remember any non-zero exit codes
+    ls -t */target/surefire-reports/*.txt | xargs tail -n +1  # show test reports in the order they ran
+    CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+fi
+
+if [ "$PIPELINE_TESTS" == "true" ]; then
+        pushd genomix-driver/target/genomix-driver-0.2.10-SNAPSHOT
+        
+        # simplified pipeline
+        bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/
+        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+        
+        # default pipeline
+        bin/genomix $RUN_LOCAL -kmerLength 55 -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ $RUN_LOCAL
+        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+        
+        # pipeline that repeats steps
+        bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HADOOP,LOW_COVERAGE,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ 
+        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+
+        popd
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
@JavierJia @anbangx @Nan-Zhang 

Our builds have started to time out, thanks to a loooong `mvn` download process in some cases and the fact that our unittests take a long time to run.  I've added caching to the `~/.m2` directory to speed up subsequent builds and have broken up the run into 3 steps-- unittests, pipeline tests, and pipelinetests with `-runLocal`.
