### PR TITLE
Fix PathMerge problem

### DIFF
--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/MessageWritable.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/MessageWritable.java
@@ -11,13 +11,13 @@ import edu.uci.ics.pregelix.api.io.WritableSizable;
 
 public class MessageWritable implements Writable, WritableSizable {
     
-    class MESSAGE_FIELDS {
+    public static class MESSAGE_FIELDS {
         public static final byte SOURCE_VERTEX_ID = 1 << 0; // used in superclass: MessageWritable
     }
     
     private VKmer sourceVertexId; // stores srcNode id
     private short flag; // stores message type
-    protected byte validMessageFlag;
+    public byte validMessageFlag;
 
     public MessageWritable() {
         sourceVertexId = new VKmer();

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
@@ -11,7 +11,7 @@ import edu.uci.ics.genomix.type.VKmer;
 
 public class PathMergeMessage extends MessageWritable {
 
-    class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    public static class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte NODE = 1 << 1; // used in subclass: PathMergeMessage
     }
 

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable.State;
 import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage;
+import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage.PATHMERGE_MESSAGE_FIELDS;
 import edu.uci.ics.genomix.pregelix.log.LogUtil;
 import edu.uci.ics.genomix.pregelix.operator.DeBruijnGraphCleanVertex;
 import edu.uci.ics.genomix.pregelix.type.MessageFlag.MESSAGETYPE;
@@ -135,6 +136,7 @@ public abstract class BasicPathMergeVertex<V extends VertexValueWritable, M exte
                         EdgeMap edgeMap = new EdgeMap();
                         edgeMap.put(iter.next(), vertex.getEdgeMap(updateEdge).get(dest));
                         outgoingMsg.getNode().setEdgeMap(newEdgetype, edgeMap); // copy into outgoingMsg
+                        outgoingMsg.validMessageFlag |= PATHMERGE_MESSAGE_FIELDS.NODE; // silly command to indicate that node has changed.
                         sendMsg(dest, outgoingMsg);
                     }
                 }


### PR DESCRIPTION
@anbangx @JavierJia @Nan-Zhang @Elmira88 

This PR is to fix the regression introduced by #51 commit 447146c. The stupid commit I've added here isn't the right way to fix the bug but it works for now.  I'm adding this PR so people can use this commit to directly test things.

When you do your upcoming testing, everyone, base it on this branch, please.

@anbangx I feel like it would be easier for us to keep track of these values if instead of a `byte` member variable, we just had the missing values initialized as `null`.  That involves more allocation and therefore GC and might make some pieces harder to deal with (you can't directly get contained values in e.g., `outgoingMsg`) but it would sure make reading/writing easier/  You'd just have to check if the value is `null` rather than actually read anything.

I've noticed in recent builds that I get a malformed byte error from HashMapWritable-- I bet there is a similar (or same?) issue there.
