### PR TITLE
Simplify travis scripts; fix -runLocal for driver; use -localOutput as home for STATS, DUMP_FASTA, and PLOT_SUBGRAPH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys  # no pw required for ssh'ing locally
     - ssh localhost -o StrictHostKeyChecking=false -n  # allow us to ssh later w/out typing "yes"
     - sudo apt-get install graphviz
-    - mvn install -q -am -pl genomix/genomix-driver/ -DskipTests=true # only install driver's prereq's
+    - mvn install -am -pl genomix/genomix-driver/ -DskipTests=true # only install driver's prereq's
 
 before_script:
     - cd genomix/genomix-pregelix/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ jdk:
     - oraclejdk7
     - openjdk7
 env:
-    - UNIT_TESTS=true PIPELINE_TESTS=false RUN_LOCAL=""
-    - UNIT_TESTS=false PIPELINE_TESTS=true RUN_LOCAL=""
-    - UNIT_TESTS=false PIPELINE_TESTS=true RUN_LOCAL="-runLocal"
+    - UNIT_TESTS=true
+    - PIPELINE_TESTS=true
+    - PIPELINE_TESTS=true RUN_LOCAL="-runLocal"
 
 # run steps
 install:

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GenerateGraphViz.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GenerateGraphViz.java
@@ -10,6 +10,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import edu.uci.ics.genomix.type.EDGETYPE;
@@ -56,22 +57,25 @@ public class GenerateGraphViz {
         }
     }
 
+    public static void convertBinToGraphViz(String srcDir, String destDir, GRAPH_TYPE graphType) throws Exception {
+        convertBinToGraphViz(new JobConf(), srcDir, destDir, graphType);
+    }
+    
     /**
      * Construct a DOT graph in memory, convert it
      * to image and store the image in the file system.
      */
-    public static void convertBinToGraphViz(String srcDir, String destDir, GRAPH_TYPE graphType) throws Exception {
+        public static void convertBinToGraphViz(JobConf conf, String srcDir, String destDir, GRAPH_TYPE graphType) throws Exception {
         GraphViz gv = new GraphViz();  
         gv.addln(gv.start_graph());
 
-        Configuration conf = new Configuration();
-        FileSystem fileSys = FileSystem.getLocal(conf);
+        FileSystem dfs = FileSystem.get(conf);
         File srcPath = new File(srcDir);
 
         String outputNode = "";
         String outputEdge = "";
         for (File f : srcPath.listFiles((FilenameFilter) (new WildcardFileFilter("part*")))) {
-            SequenceFile.Reader reader = new SequenceFile.Reader(fileSys, new Path(f.getAbsolutePath()), conf);
+            SequenceFile.Reader reader = new SequenceFile.Reader(dfs, new Path(f.getAbsolutePath()), conf);
             VKmer key = (VKmer) ReflectionUtils.newInstance(reader.getKeyClass(), conf);
             Node value = (Node) ReflectionUtils.newInstance(reader.getValueClass(), conf);
 

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GraphViz.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/minicluster/GraphViz.java
@@ -175,7 +175,7 @@ public class GraphViz {
      *            A File object to where we want to write.
      * @return Success: 1, Failure: -1
      */
-    public int writeGraphToFile(byte[] img, File to) {
+    public static int writeGraphToFile(byte[] img, File to) {
         try {
             FileOutputStream fos = new FileOutputStream(to);
             fos.write(img);

--- a/genomix/genomix-driver/pom.xml
+++ b/genomix/genomix-driver/pom.xml
@@ -324,6 +324,16 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
 			<version>0.20.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>tomcat</groupId>
+					<artifactId>jasper-runtime</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>tomcat</groupId>
+					<artifactId>jasper-compiler</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -98,7 +98,8 @@ public class GenomixDriver {
                 break;
             case MERGE_P2:
                 //                queuePregelixJob(P2ForPathMergeVertex.getConfiguredJob(conf, P2ForPathMergeVertex.class));
-                break;
+                //                break;
+                throw new UnsupportedOperationException("MERGE_P2 has errors!");
             case MERGE:
             case MERGE_P4:
                 pregelixJobs.add(P4ForPathMergeVertex.getConfiguredJob(conf, P4ForPathMergeVertex.class));
@@ -155,23 +156,14 @@ public class GenomixDriver {
                     pregelixJobs.add(ExtractSubgraphVertex.getConfiguredJob(conf, ExtractSubgraphVertex.class));
                 }
                 flushPendingJobs(conf);
-                if (conf.get(GenomixJobConf.LOCAL_OUTPUT_DIR) != null) {
-                    String localOutputDir = conf.get(GenomixJobConf.LOCAL_OUTPUT_DIR) + File.separator
-                            + new File(curOutput).getName() + "-PLOT";
-                    //copy bin to local and append "-PLOT" to the name
-                    GenomixClusterManager.copyBinToLocal(conf, curOutput, localOutputDir);
-                    //covert bin to graphviz
-                    String graphvizDir = localOutputDir + File.separator + "graphviz";
-                    GenerateGraphViz.convertBinToGraphViz(localOutputDir + File.separator + "bin", graphvizDir,
-                            GRAPH_TYPE.valueOf(conf.get(GenomixJobConf.PLOT_SUBGRAPH_GRAPH_VERBOSITY)));
-                    LOG.info("Copying graphviz to local: " + graphvizDir);
-                }
+                //copy bin to local and append "-PLOT" to the name);
+                GenerateGraphViz.convertBinToGraphViz(conf, curOutput, curOutput + "-PLOT",
+                        GRAPH_TYPE.valueOf(conf.get(GenomixJobConf.PLOT_SUBGRAPH_GRAPH_VERBOSITY)));
                 curOutput = prevOutput; // next job shouldn't use the truncated graph or plots
                 stepNum--;
                 break;
             case STATS:
                 flushPendingJobs(conf);
-
                 curOutput = prevOutput + "-STATS";
                 stepNum--;
                 Counters counters = GraphStatistics.run(prevOutput, curOutput, conf);

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -333,7 +333,17 @@ public class GenomixDriver {
             return;
         }
         GenomixDriver driver = new GenomixDriver();
-        driver.runGenomix(conf);
+        try {
+            driver.runGenomix(conf);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        } finally {
+            if (Boolean.parseBoolean(conf.get(GenomixJobConf.RUN_LOCAL))) {
+                // force the in-memory pregelix NC to shut down
+                System.exit(0);
+            }
+        }
     }
 
 }

--- a/genomix/genomix-driver/src/test/java/edu/uci/ics/genomix/driver/comparation/HyrackVSHadoopTest.java
+++ b/genomix/genomix-driver/src/test/java/edu/uci/ics/genomix/driver/comparation/HyrackVSHadoopTest.java
@@ -152,13 +152,13 @@ public class HyrackVSHadoopTest {
         Path path = new Path(hyracksResultFileName);
         GenomixClusterManager.copyBinToLocal(conf, HDFS_OUTPUT_PATH_HYRACKS + File.separator + testFile.getName(), path
                 .getParent().toString());
-        GenerateGraphViz.convertBinToGraphViz(path.getParent().toString() + "/bin", path.getParent()
+        GenerateGraphViz.writeLocalBinToLocalSvg(path.getParent().toString() + "/bin", path.getParent()
                 .toString() + "/graphviz", GRAPH_TYPE.DIRECTED_GRAPH_WITH_ALLDETAILS);
 
         path = new Path(hadoopResultFileName);
         GenomixClusterManager.copyBinToLocal(conf, HDFS_OUTPUT_PATH_HADOOP + File.separator + testFile.getName(), path
                 .getParent().toString());
-        GenerateGraphViz.convertBinToGraphViz(path.getParent().toString() + "/bin", path.getParent()
+        GenerateGraphViz.writeLocalBinToLocalSvg(path.getParent().toString() + "/bin", path.getParent()
                 .toString() + "/graphviz", GRAPH_TYPE.DIRECTED_GRAPH_WITH_ALLDETAILS);
 
         TestUtils.compareFilesBySortingThemLineByLine(new File(hyracksResultFileName), new File(hadoopResultFileName));

--- a/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/converttofasta/ConvertToFasta.java
+++ b/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/converttofasta/ConvertToFasta.java
@@ -6,6 +6,8 @@ import java.util.logging.Logger;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileOutputFormat;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.MapReduceBase;
 import org.apache.hadoop.mapred.Mapper;
@@ -34,7 +36,8 @@ public class ConvertToFasta extends MapReduceBase implements Mapper<VKmer, Node,
         output.collect(textKey, textValue);
     }
 
-    public static void run(String outputPath, int numReducers, GenomixJobConf baseConf) throws IOException {
+    public static void run(String inputPath, String outputPath, int numReducers, GenomixJobConf baseConf)
+            throws IOException {
 
         GenomixJobConf conf = new GenomixJobConf(baseConf);
 
@@ -48,11 +51,12 @@ public class ConvertToFasta extends MapReduceBase implements Mapper<VKmer, Node,
         conf.setInputFormat(SequenceFileInputFormat.class);
         conf.setOutputFormat(TextOutputFormat.class);
 
+        // TODO get new output format that doesn't use tabs between values
         conf.setOutputKeyClass(Text.class);
         conf.setOutputValueClass(Text.class);
 
-//        FileInputFormat.setInputPaths(conf, new Path(inputPath));
-//        FileOutputFormat.setOutputPath(conf, new Path(outputPath));
+        FileInputFormat.setInputPaths(conf, new Path(inputPath));
+        FileOutputFormat.setOutputPath(conf, new Path(outputPath));
         conf.setNumReduceTasks(numReducers);
 
         FileSystem dfs = FileSystem.get(conf);

--- a/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/converttofasta/ConvertToFasta.java
+++ b/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/converttofasta/ConvertToFasta.java
@@ -43,6 +43,8 @@ public class ConvertToFasta extends MapReduceBase implements Mapper<VKmer, Node,
     }
 
     private static class FastaOutputFormat<K, V> extends FileOutputFormat<K, V> {
+        
+        private static final String OUTPUT_FILENAME = "genomix-scaffolds.fasta";
 
         protected static class FastaRecordWriter<K, V> implements RecordWriter<K, V> {
             private DataOutputStream out;
@@ -77,7 +79,7 @@ public class ConvertToFasta extends MapReduceBase implements Mapper<VKmer, Node,
 
         public RecordWriter<K, V> getRecordWriter(FileSystem ignored, JobConf job, String name, Progressable progress)
                 throws IOException {
-            Path file = FileOutputFormat.getTaskOutputPath(job, name);
+            Path file = new Path(FileOutputFormat.getTaskOutputPath(job, name), OUTPUT_FILENAME);
             FileSystem fs = file.getFileSystem(job);
             FSDataOutputStream fileOut = fs.create(file, progress);
             return new FastaRecordWriter<K, V>(fileOut);

--- a/genomix/genomix-hadoop/src/test/java/edu/uci/ics/genomix/hadoop/contrailgraphbuilding/GraphBuildingTestCase.java
+++ b/genomix/genomix-hadoop/src/test/java/edu/uci/ics/genomix/hadoop/contrailgraphbuilding/GraphBuildingTestCase.java
@@ -60,7 +60,7 @@ public class GraphBuildingTestCase extends TestCase {
         //        Path dest = new Path(RESULT_PATH);
         //        dfs.copyToLocalFile(src, dest);
         GenomixClusterManager.copyBinToLocal(conf, RESULT_PATH, RESULT_PATH);
-        GenerateGraphViz.convertBinToGraphViz(RESULT_PATH + "/bin", RESULT_PATH + "/graphviz",
+        GenerateGraphViz.writeLocalBinToLocalSvg(RESULT_PATH + "/bin", RESULT_PATH + "/graphviz",
                 GRAPH_TYPE.DIRECTED_GRAPH_WITH_ALLDETAILS);
     }
 }

--- a/genomix/genomix-hyracks/src/test/java/edu/uci/ics/genomix/hyracks/graph/test/BatchTestFilesTest.java
+++ b/genomix/genomix-hyracks/src/test/java/edu/uci/ics/genomix/hyracks/graph/test/BatchTestFilesTest.java
@@ -160,7 +160,7 @@ public class BatchTestFilesTest {
         Path path = new Path(resultFileName);
         GenomixClusterManager.copyBinToLocal(conf, HDFS_OUTPUT_PATH + File.separator + testFile.getName(), path
                 .getParent().toString());
-        GenerateGraphViz.convertBinToGraphViz(path.getParent().toString() + "/bin", path.getParent().toString()
+        GenerateGraphViz.writeLocalBinToLocalSvg(path.getParent().toString() + "/bin", path.getParent().toString()
                 + "/graphviz", GRAPH_TYPE.DIRECTED_GRAPH_WITH_ALLDETAILS);
         TestUtils.compareFilesBySortingThemLineByLine(new File(resultFileName), new File(expectFileName));
     }

--- a/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/jobrun/BasicSmallTestCase.java
+++ b/genomix/genomix-pregelix/src/test/java/edu/uci/ics/genomix/pregelix/jobrun/BasicSmallTestCase.java
@@ -94,7 +94,7 @@ public class BasicSmallTestCase extends TestCase {
         //covert bin to text
         GenerateTextFile.convertGraphCleanOutputToText(binFileDir, textFileDir);
         //covert bin to graphviz
-        GenerateGraphViz.convertBinToGraphViz(binFileDir, graphvizFileDir,
+        GenerateGraphViz.writeLocalBinToLocalSvg(binFileDir, graphvizFileDir,
                 GRAPH_TYPE.DIRECTED_GRAPH_WITH_ALLDETAILS);
         //generate statistic counters
         //        generateStatisticsResult(statisticsFileDir);

--- a/genomix/run_tests.sh
+++ b/genomix/run_tests.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-if [ -z "$UNIT_TESTS" ]; then UNIT_TESTS=true; fi
-if [ -z "$PIPELINE_TESTS" ]; then PIPELINE_TESTS=true; fi
-if [ -z "$RUN_LOCAL" ]; then RUN_LOCAL=""; fi
+# if the user didn't specify any specific tests to run, then run them all
+if [[ -z "$UNIT_TESTS" && -z "$PIPELINE_TESTS" && -z "$RUN_LOCAL" ]]; then
+    UNIT_TESTS=true
+    PIPELINE_TESTS=true
+    RUN_LOCAL=""
+fi
 
 echo "UNIT_TESTS: $UNIT_TESTS"
 echo "PIPELINE_TESTS: $PIPELINE_TESTS"

--- a/genomix/run_tests.sh
+++ b/genomix/run_tests.sh
@@ -9,28 +9,33 @@ echo "PIPELINE_TESTS: $PIPELINE_TESTS"
 echo "RUN_LOCAL: $RUN_LOCAL"
 
 EXIT_CODE=0
-
-if [ "$UNIT_TESTS" == "true" ]; then 
-    mvn package -q -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/worker.logging.properties
+function run_and_save_exit_code {
+    eval "${cmd[@]}"
     CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE  # remember any non-zero exit codes
+    echo "The command \"${cmd[@]}\" exited with $CODE"
+}
+
+if [ "$UNIT_TESTS" == "true" ]; then
+    cmd=( mvn package -q -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/worker.logging.properties )
+    run_and_save_exit_code
+    
     ls -t */target/surefire-reports/*.txt | xargs tail -n +1  # show test reports in the order they ran
-    CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
 fi
 
 if [ "$PIPELINE_TESTS" == "true" ]; then
         pushd genomix-driver/target/genomix-driver-0.2.10-SNAPSHOT
         
         # simplified pipeline
-        bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/
-        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+        cmd=( bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ )
+        run_and_save_exit_code
         
         # default pipeline
-        bin/genomix $RUN_LOCAL -kmerLength 55 -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ $RUN_LOCAL
-        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+        cmd=( bin/genomix $RUN_LOCAL -kmerLength 55 -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ $RUN_LOCAL )
+        run_and_save_exit_code
         
         # pipeline that repeats steps
-        bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HADOOP,LOW_COVERAGE,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ 
-        CODE=$? && [[ $CODE != 0 ]] && EXIT_CODE=$CODE
+        cmd=( bin/genomix $RUN_LOCAL -kmerLength 55 -pipelineOrder BUILD_HADOOP,LOW_COVERAGE,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE,BUBBLE,MERGE,SPLIT_REPEAT,MERGE -localInput ../../src/test/resources/data/sequence/pathmerge/hg19.chr18.skip12K.first1K.1Kreads/ )
+        run_and_save_exit_code
 
         popd
 fi

--- a/genomix/run_tests.sh
+++ b/genomix/run_tests.sh
@@ -19,7 +19,7 @@ function run_and_save_exit_code {
 }
 
 if [ "$UNIT_TESTS" == "true" ]; then
-    cmd=( mvn package -q -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/worker.logging.properties )
+    cmd=( mvn package -e -Djava.util.logging.config.file=genomix-driver/src/main/resources/conf/worker.logging.properties )
     run_and_save_exit_code
     
     ls -t */target/surefire-reports/*.txt | xargs tail -n +1  # show test reports in the order they ran


### PR DESCRIPTION
@anbangx @Nan-Zhang @JavierJia 

Sorry to submit these three separate ideas in one PR.
- With these changes, the `-runLocal` option should no longer stall when running the driver.  I still don't have a solution for test cases run within eclipse, where I occasionally see the tests hang.  We shouldn't see the "no output received in 10 minutes" error you see in travis right now.
- When we separated the unit tests from the pipeline tests, we lost the actual command that was failing for pipeline tests.  Travis now prints it.
- `STATS`, `DUMP_FASTA`, and `PLOT_SUBGRAPH` now all write to HDFS but will be copied to the local output directory if the user specifies `-localOutput`.  Their naming is also simplified to be clearer (if the last clean step had output `05-MERGE`, then these steps will be outputted as `05-MERGE-DUMP_FASTA` rather than `06-DUMP_FASTA`. That is, the basename is kept for these jobs that don't procude their own output. This should  help our testing.
