### PR TITLE
In pregelix messages, use null values to indicate usage

### DIFF
--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/BFSTraverseMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/BFSTraverseMessage.java
@@ -16,7 +16,7 @@ import edu.uci.ics.genomix.type.VKmerList;
 
 public class BFSTraverseMessage extends MessageWritable {
 
-    class BFS_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    protected class BFS_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte PATH_LIST_AND_EDGETYPE_LIST = 1 << 1; // used in BFSTraverseMessage
         public static final byte SRC_AND_DEST_READ_HEAD_ORIENTATION = 1 << 2; // used in BFSTraverseMessage
         public static final byte TARGET_VERTEX_ID = 1 << 3; // used in BFSTraverseMessage
@@ -28,62 +28,68 @@ public class BFSTraverseMessage extends MessageWritable {
     private VKmerList pathList; //use for BFSTravese
     private EdgeTypeList edgeTypeList; //use for BFSTravese
     private VKmer targetVertexId; //use for BFSTravese
-    private long readId; //use for BFSTravese
+    private Long readId; //use for BFSTravese
     private READHEAD_ORIENTATION srcReadHeadOrientation; //use for BFSTravese
     private READHEAD_ORIENTATION destReadHeadOrientation; //use for BFSTravese
-    private int totalBFSLength;
+    private Integer totalBFSLength;
     private HashMapWritable<LongWritable, ArrayListWritable<SearchInfo>> scaffoldingMap;
 
     public BFSTraverseMessage() {
         super();
-        pathList = new VKmerList();
-        edgeTypeList = new EdgeTypeList();
-        targetVertexId = new VKmer();
-        readId = 0;
-        srcReadHeadOrientation = READHEAD_ORIENTATION.UNFLIPPED;
-        destReadHeadOrientation = READHEAD_ORIENTATION.UNFLIPPED;
-        totalBFSLength = 0;
-        scaffoldingMap = new HashMapWritable<LongWritable, ArrayListWritable<SearchInfo>>();
+        pathList = null;
+        edgeTypeList = null;
+        targetVertexId = null;
+        readId = null;
+        srcReadHeadOrientation = null;
+        destReadHeadOrientation = null;
+        totalBFSLength = null;
+        scaffoldingMap = null;
     }
 
     public void reset() {
         super.reset();
-        pathList.reset();
-        edgeTypeList.clear();
-        targetVertexId.reset(0);
-        readId = 0;
-        srcReadHeadOrientation = READHEAD_ORIENTATION.UNFLIPPED;
-        destReadHeadOrientation = READHEAD_ORIENTATION.UNFLIPPED;
-        totalBFSLength = 0;
-        scaffoldingMap.clear();
+        pathList = null;
+        edgeTypeList = null;
+        targetVertexId = null;
+        readId = null;
+        srcReadHeadOrientation = null;
+        destReadHeadOrientation = null;
+        totalBFSLength = null;
+        scaffoldingMap = null;
     }
 
     public VKmerList getPathList() {
+        if (pathList == null) {
+            pathList = new VKmerList();
+        }
         return pathList;
     }
 
     public void setPathList(VKmerList pathList) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST;
-        this.pathList = pathList;
+        getPathList().setCopy(pathList); // TODO should be a copy?
     }
 
     public EdgeTypeList getEdgeTypeList() {
+        if (edgeTypeList == null) {
+            edgeTypeList = new EdgeTypeList();
+        }
         return edgeTypeList;
     }
 
     public void setEdgeTypeList(EdgeTypeList edgeDirsList) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST;
-        this.edgeTypeList.clear();
-        this.edgeTypeList.addAll(edgeDirsList);
+        getEdgeTypeList().clear();
+        getEdgeTypeList().addAll(edgeDirsList);
     }
 
     public VKmer getTargetVertexId() {
+        if (targetVertexId == null) {
+            targetVertexId = new VKmer();
+        }
         return targetVertexId;
     }
 
     public void setTargetVertexId(VKmer targetVertexId) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.TARGET_VERTEX_ID;
-        this.targetVertexId.setAsCopy(targetVertexId);
+        getTargetVertexId().setAsCopy(targetVertexId);
     }
 
     public long getReadId() {
@@ -91,7 +97,6 @@ public class BFSTraverseMessage extends MessageWritable {
     }
 
     public void setReadId(long readId) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.READ_ID;
         this.readId = readId;
     }
 
@@ -100,7 +105,6 @@ public class BFSTraverseMessage extends MessageWritable {
     }
 
     public void setSrcReadHeadOrientation(READHEAD_ORIENTATION srcReadHeadOrientation) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION;
         this.srcReadHeadOrientation = srcReadHeadOrientation;
     }
 
@@ -109,7 +113,6 @@ public class BFSTraverseMessage extends MessageWritable {
     }
 
     public void setDestReadHeadOrientation(READHEAD_ORIENTATION destReadHeadOrientation) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION;
         this.destReadHeadOrientation = destReadHeadOrientation;
     }
 
@@ -118,60 +121,92 @@ public class BFSTraverseMessage extends MessageWritable {
     }
 
     public void setTotalBFSLength(int totalBFSLength) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.TOTAL_BFS_LENGTH;
         this.totalBFSLength = totalBFSLength;
     }
 
     public HashMapWritable<LongWritable, ArrayListWritable<SearchInfo>> getScaffoldingMap() {
+        if (scaffoldingMap == null) {
+            scaffoldingMap = new HashMapWritable<LongWritable, ArrayListWritable<SearchInfo>>();
+        }
         return scaffoldingMap;
     }
 
     public void setScaffoldingMap(HashMapWritable<LongWritable, ArrayListWritable<SearchInfo>> scaffoldingMap) {
-        validMessageFlag |= BFS_MESSAGE_FIELDS.SCAFFOLDING_MAP;
-        this.scaffoldingMap.clear();
-        this.scaffoldingMap.putAll(scaffoldingMap);
+        getScaffoldingMap().clear();
+        getScaffoldingMap().putAll(scaffoldingMap);
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
-        reset();
         super.readFields(in);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.READ_ID) > 0)
+        if ((messageFields & BFS_MESSAGE_FIELDS.READ_ID) != 0) {
             readId = in.readLong();
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST) > 0) {
-            pathList.readFields(in);
-            edgeTypeList.readFields(in);
         }
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.TARGET_VERTEX_ID) > 0)
-            targetVertexId.readFields(in);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION) > 0) {
+        if ((messageFields & BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST) != 0) {
+            getPathList().readFields(in);
+            getEdgeTypeList().readFields(in);
+        }
+        if ((messageFields & BFS_MESSAGE_FIELDS.TARGET_VERTEX_ID) != 0) {
+            getTargetVertexId().readFields(in);
+        }
+        if ((messageFields & BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION) != 0) {
             srcReadHeadOrientation = READHEAD_ORIENTATION.fromByte(in.readByte());
             destReadHeadOrientation = READHEAD_ORIENTATION.fromByte(in.readByte());
         }
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.TOTAL_BFS_LENGTH) > 0)
+        if ((messageFields & BFS_MESSAGE_FIELDS.TOTAL_BFS_LENGTH) != 0) {
             totalBFSLength = in.readInt();
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.SCAFFOLDING_MAP) > 0)
-            scaffoldingMap.readFields(in);
+        }
+        if ((messageFields & BFS_MESSAGE_FIELDS.SCAFFOLDING_MAP) != 0) {
+            getScaffoldingMap().readFields(in);
+        }
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.READ_ID) > 0)
+        if (readId != null) {
             out.writeLong(readId);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST) > 0) {
+        }
+        if (pathList != null || edgeTypeList != null) {
             pathList.write(out);
             edgeTypeList.write(out);
         }
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.TARGET_VERTEX_ID) > 0)
+        if (targetVertexId != null) {
             targetVertexId.write(out);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION) > 0) {
+        }
+        if (srcReadHeadOrientation != null || destReadHeadOrientation != null) {
             out.writeByte(srcReadHeadOrientation.get());
             out.writeByte(destReadHeadOrientation.get());
         }
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.TOTAL_BFS_LENGTH) > 0)
+        if (totalBFSLength != null) {
             out.writeInt(totalBFSLength);
-        if ((validMessageFlag & BFS_MESSAGE_FIELDS.SCAFFOLDING_MAP) > 0)
+        }
+        if (scaffoldingMap != null) {
             scaffoldingMap.write(out);
+        }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (readId != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.READ_ID;
+        }
+        if (pathList != null || edgeTypeList != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.PATH_LIST_AND_EDGETYPE_LIST;
+        }
+        if (targetVertexId != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.TARGET_VERTEX_ID;
+        }
+        if (srcReadHeadOrientation != null || destReadHeadOrientation != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.SRC_AND_DEST_READ_HEAD_ORIENTATION;
+        }
+        if (totalBFSLength != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.TOTAL_BFS_LENGTH;
+        }
+        if (scaffoldingMap != null) {
+            messageFields |= BFS_MESSAGE_FIELDS.SCAFFOLDING_MAP;
+        }
+        return messageFields;
     }
 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/BubbleMergeMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/BubbleMergeMessage.java
@@ -5,6 +5,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Comparator;
 
+import edu.uci.ics.genomix.pregelix.io.message.SymmetryCheckerMessage.SYMMERTRYCHECKER_MESSAGE_FIELDS;
 import edu.uci.ics.genomix.type.EDGETYPE;
 import edu.uci.ics.genomix.type.EdgeMap;
 import edu.uci.ics.genomix.type.Node;
@@ -13,11 +14,13 @@ import edu.uci.ics.genomix.type.VKmer;
 
 public class BubbleMergeMessage extends MessageWritable {
 
-    class BUBBLEMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    protected class BUBBLEMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte NODE = 1 << 1; // used in BubbleMergeMessage
-        public static final byte MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE = 1 << 2; // used in BubbleMergeMessage
-        public static final byte MINOR_VERTEX_ID_AND_MINOR_TO_BUBBLE_EDGETYPE = 1 << 3; // used in BubbleMergeMessage
-        public static final byte TOP_COVERAGE_VERTEX_ID = 1 << 4; // used in BubbleMergeMessage
+        public static final byte MAJOR_VERTEX_ID = 1 << 2; // used in BubbleMergeMessage
+        public static final byte MINOR_VERTEX_ID = 1 << 3; // used in BubbleMergeMessage
+        public static final byte MAJOR_TO_BUBBLE_EDGETYPE = 1 << 4; // used in BubbleMergeMessage
+        public static final byte MINOR_TO_BUBBLE_EDGETYPE = 1 << 5; // used in BubbleMergeMessage
+        public static final byte TOP_COVERAGE_VERTEX_ID = 1 << 6; // used in BubbleMergeMessage
     }
 
     private VKmer majorVertexId; //use for MergeBubble
@@ -29,12 +32,12 @@ public class BubbleMergeMessage extends MessageWritable {
 
     public BubbleMergeMessage() {
         super();
-        majorVertexId = new VKmer();
-        minorVertexId = new VKmer();
-        node = new Node();
-        majorToBubbleEdgetype = EDGETYPE.FF;
-        minorToBubbleEdgetype = EDGETYPE.FF;
-        topCoverageVertexId = new VKmer();
+        majorVertexId = null;
+        minorVertexId = null;
+        node = null;
+        majorToBubbleEdgetype = null;
+        minorToBubbleEdgetype = null;
+        topCoverageVertexId = null;
     }
 
     public BubbleMergeMessage(BubbleMergeMessage msg) {
@@ -42,79 +45,83 @@ public class BubbleMergeMessage extends MessageWritable {
     }
 
     public void set(BubbleMergeMessage msg) {
-        this.setSourceVertexId(msg.getSourceVertexId());
-        this.setFlag(msg.getFlag());
-        this.setMajorVertexId(msg.getMajorVertexId());
-        this.setMinorVertexId(msg.getMinorVertexId());
+        this.setSourceVertexId(msg.sourceVertexId);
+        this.setFlag(msg.flag);
+        this.setMajorVertexId(msg.majorVertexId);
+        this.setMinorVertexId(msg.minorVertexId);
         this.setNode(msg.node);
-        this.setMajorToBubbleEdgetype(msg.getMajorToBubbleEdgetype());
-        this.setMinorToBubbleEdgetype(msg.getMinorToBubbleEdgetype());
+        this.setMajorToBubbleEdgetype(msg.majorToBubbleEdgetype);
+        this.setMinorToBubbleEdgetype(msg.minorToBubbleEdgetype);
         this.setTopCoverageVertexId(msg.topCoverageVertexId);
     }
 
+    @Override
     public void reset() {
         super.reset();
-        majorVertexId.reset(0);
-        minorVertexId.reset(0);
-        node.reset();
-        majorToBubbleEdgetype = EDGETYPE.FF;
-        minorToBubbleEdgetype = EDGETYPE.FF;
-        topCoverageVertexId.reset(0);
+        majorVertexId = null;
+        minorVertexId = null;
+        node = null;
+        majorToBubbleEdgetype = null;
+        minorToBubbleEdgetype = null;
+        topCoverageVertexId = null;
     }
 
     public EdgeMap getMinorToBubbleEdgeMap() {
+        if (node == null) {
+            node = new Node();
+        }
         return node.getEdgeMap(getMinorToBubbleEdgetype().mirror());
     }
 
     public void addNewMajorToBubbleEdges(boolean sameOrientation, BubbleMergeMessage msg, VKmer topKmer) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE;
         EDGETYPE majorToBubble = msg.getMajorToBubbleEdgetype();
-        ReadIdSet newReadIds = msg.getNode().getEdgeMap(majorToBubble.mirror())
-                .get(msg.getMajorVertexId());
-        node.getEdgeMap(sameOrientation ? majorToBubble : majorToBubble.flipNeighbor()).unionAdd(topKmer, newReadIds);
+        ReadIdSet newReadIds = msg.getNode().getEdgeMap(majorToBubble.mirror()).get(msg.getMajorVertexId());
+        getNode().getEdgeMap(sameOrientation ? majorToBubble : majorToBubble.flipNeighbor()).unionAdd(topKmer,
+                newReadIds);
     }
 
     public VKmer getMajorVertexId() {
+        if (majorVertexId == null) {
+            majorVertexId = new VKmer();
+        }
         return majorVertexId;
     }
 
     public void setMajorVertexId(VKmer majorVertexId) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE;
-        if (this.majorVertexId == null)
-            this.majorVertexId = new VKmer();
-        this.majorVertexId.setAsCopy(majorVertexId);
+        getMajorVertexId().setAsCopy(majorVertexId);
     }
 
     public VKmer getMinorVertexId() {
+        if (minorVertexId == null) {
+            minorVertexId = new VKmer();
+        }
         return minorVertexId;
     }
 
     public void setMinorVertexId(VKmer minorVertexId) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID_AND_MINOR_TO_BUBBLE_EDGETYPE;
-        if (this.minorVertexId == null)
-            this.minorVertexId = new VKmer();
-        this.minorVertexId.setAsCopy(minorVertexId);
+        getMinorVertexId().setAsCopy(minorVertexId);
     }
 
     public VKmer getTopCoverageVertexId() {
+        if (topCoverageVertexId == null) {
+            topCoverageVertexId = new VKmer();
+        }
         return topCoverageVertexId;
     }
 
     public void setTopCoverageVertexId(VKmer topCoverageVertexId) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.TOP_COVERAGE_VERTEX_ID;
-        if (this.topCoverageVertexId == null)
-            this.topCoverageVertexId = new VKmer();
-        this.topCoverageVertexId.setAsCopy(topCoverageVertexId);
+        getTopCoverageVertexId().setAsCopy(topCoverageVertexId);
     }
 
     public Node getNode() {
+        if (node == null) {
+            node = new Node();
+        }
         return node;
     }
 
     public void setNode(Node node) {
-        if (this.node == null)
-            this.node = new Node();
-        this.node.setAsCopy(node);
+        getNode().setAsCopy(node);
     }
 
     public EDGETYPE getMajorToBubbleEdgetype() {
@@ -122,7 +129,6 @@ public class BubbleMergeMessage extends MessageWritable {
     }
 
     public void setMajorToBubbleEdgetype(EDGETYPE majorToBubbleEdgetype) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE;
         this.majorToBubbleEdgetype = majorToBubbleEdgetype;
     }
 
@@ -131,43 +137,77 @@ public class BubbleMergeMessage extends MessageWritable {
     }
 
     public void setMinorToBubbleEdgetype(EDGETYPE minorToBubbleEdgetype) {
-        validMessageFlag |= BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID_AND_MINOR_TO_BUBBLE_EDGETYPE;
         this.minorToBubbleEdgetype = minorToBubbleEdgetype;
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
-        reset();
         super.readFields(in);
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE) > 0) {
-            majorVertexId.readFields(in);
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID) != 0) {
+            getMajorVertexId().readFields(in);
+        }
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_TO_BUBBLE_EDGETYPE) != 0) {
             majorToBubbleEdgetype = EDGETYPE.fromByte(in.readByte());
         }
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID_AND_MINOR_TO_BUBBLE_EDGETYPE) > 0) {
-            minorVertexId.readFields(in);
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID) != 0) {
+            getMinorVertexId().readFields(in);
+        }
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.MINOR_TO_BUBBLE_EDGETYPE) != 0) {
             minorToBubbleEdgetype = EDGETYPE.fromByte(in.readByte());
         }
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.NODE) > 0)
-            node.readFields(in);
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.TOP_COVERAGE_VERTEX_ID) > 0)
-            topCoverageVertexId.readFields(in);
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.NODE) != 0) {
+            getNode().readFields(in);
+        }
+        if ((messageFields & BUBBLEMERGE_MESSAGE_FIELDS.TOP_COVERAGE_VERTEX_ID) != 0) {
+            getTopCoverageVertexId().readFields(in);
+        }
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID_AND_MAJOR_TO_BUBBLE_EDGETYPE) > 0) {
+        if (majorVertexId != null) {
             majorVertexId.write(out);
+        }
+        if (majorToBubbleEdgetype != null) {
             out.writeByte(majorToBubbleEdgetype.get());
         }
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID_AND_MINOR_TO_BUBBLE_EDGETYPE) > 0) {
+        if (minorVertexId != null) {
             minorVertexId.write(out);
+        }
+        if (minorToBubbleEdgetype != null) {
             out.writeByte(minorToBubbleEdgetype.get());
         }
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.NODE) > 0)
+        if (node != null) {
             node.write(out);
-        if ((validMessageFlag & BUBBLEMERGE_MESSAGE_FIELDS.TOP_COVERAGE_VERTEX_ID) > 0)
+        }
+        if (topCoverageVertexId != null) {
             topCoverageVertexId.write(out);
+        }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (majorVertexId != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_VERTEX_ID;
+        }
+        if (minorVertexId != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.MINOR_VERTEX_ID;
+        }
+        if (majorToBubbleEdgetype != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.MAJOR_TO_BUBBLE_EDGETYPE;
+        }
+        if (minorToBubbleEdgetype != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.MINOR_TO_BUBBLE_EDGETYPE;
+        }
+        if (node != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.NODE;
+        }
+        if (topCoverageVertexId != null) {
+            messageFields |= BUBBLEMERGE_MESSAGE_FIELDS.TOP_COVERAGE_VERTEX_ID;
+        }
+        return messageFields;
     }
 
     public static class SortByCoverage implements Comparator<BubbleMergeMessage> {

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/MessageWritable.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/MessageWritable.java
@@ -11,13 +11,13 @@ import edu.uci.ics.pregelix.api.io.WritableSizable;
 
 public class MessageWritable implements Writable, WritableSizable {
     
-    class MESSAGE_FIELDS {
+    public static class MESSAGE_FIELDS {
         public static final byte SOURCE_VERTEX_ID = 1 << 0; // used in superclass: MessageWritable
     }
     
     private VKmer sourceVertexId; // stores srcNode id
     private short flag; // stores message type
-    protected byte validMessageFlag;
+    public byte validMessageFlag;
 
     public MessageWritable() {
         sourceVertexId = new VKmer();

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
@@ -11,7 +11,7 @@ import edu.uci.ics.genomix.type.VKmer;
 
 public class PathMergeMessage extends MessageWritable {
 
-    public static class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    protected static class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte NODE = 1 << 1; // used in subclass: PathMergeMessage
     }
 
@@ -19,7 +19,7 @@ public class PathMergeMessage extends MessageWritable {
 
     public PathMergeMessage() {
         super();
-        node = new Node();
+        node = null;
     }
 
     public PathMergeMessage(PathMergeMessage other) {
@@ -29,48 +29,61 @@ public class PathMergeMessage extends MessageWritable {
 
     public void setAsCopy(PathMergeMessage other) {
         super.setAsCopy(other);
-        this.node.setAsCopy(other.getNode());
+        getNode().setAsCopy(other.getNode());
     }
 
+    @Override
     public void reset() {
         super.reset();
-        node.reset();
+        node = null;
     }
 
     public VKmer getInternalKmer() {
-        return node.getInternalKmer();
+        return getNode().getInternalKmer();
     }
 
     public void setInternalKmer(VKmer internalKmer) {
-        this.node.setInternalKmer(internalKmer);
+        getNode().setInternalKmer(internalKmer);
     }
 
     public EdgeMap getEdgeList(EDGETYPE edgeType) {
-        return node.getEdgeMap(edgeType);
+        return getNode().getEdgeMap(edgeType);
     }
 
     public Node getNode() {
+        if (node == null) {
+            node = new Node();
+        }
         return node;
     }
 
     public void setNode(Node node) {
-        this.validMessageFlag |= PATHMERGE_MESSAGE_FIELDS.NODE;
-        this.node.setAsCopy(node);
+        getNode().setAsCopy(node);
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
-        reset();
         super.readFields(in);
-        if ((validMessageFlag & PATHMERGE_MESSAGE_FIELDS.NODE) > 0)
-            node.readFields(in);
+        if ((messageFields & PATHMERGE_MESSAGE_FIELDS.NODE) != 0) {
+            getNode().readFields(in);
+        }
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
-        if ((validMessageFlag & PATHMERGE_MESSAGE_FIELDS.NODE) > 0)
+        if (node != null) {
             node.write(out);
+        }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (node != null) {
+            messageFields |= PATHMERGE_MESSAGE_FIELDS.NODE;
+        }
+        return messageFields;
     }
 
     @Override
@@ -78,9 +91,9 @@ public class PathMergeMessage extends MessageWritable {
         StringBuilder sbuilder = new StringBuilder();
         sbuilder.append('{');
         sbuilder.append("src:[");
-        sbuilder.append(getSourceVertexId().toString()).append(']').append("\t");
+        sbuilder.append(sourceVertexId == null ? "null" : getSourceVertexId().toString()).append(']').append("\t");
         sbuilder.append("node:");
-        sbuilder.append(node.toString()).append("\t");
+        sbuilder.append(node == null ? "null" : node.toString()).append("\t");
         sbuilder.append('}');
         return sbuilder.toString();
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/PathMergeMessage.java
@@ -11,7 +11,7 @@ import edu.uci.ics.genomix.type.VKmer;
 
 public class PathMergeMessage extends MessageWritable {
 
-    class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    public static class PATHMERGE_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte NODE = 1 << 1; // used in subclass: PathMergeMessage
     }
 

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/SplitRepeatMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/SplitRepeatMessage.java
@@ -11,7 +11,7 @@ import edu.uci.ics.genomix.type.VKmer;
 
 public class SplitRepeatMessage extends MessageWritable {
 
-    class SPLITREPEAT_MESSAGE_FIELDS extends MESSAGE_FIELDS {
+    protected class SPLITREPEAT_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte CREATED_EDGE = 1 << 1; // used in subclass: SplitRepeatMessage
     }
 
@@ -19,23 +19,30 @@ public class SplitRepeatMessage extends MessageWritable {
 
     public SplitRepeatMessage() {
         super();
-        createdEdge = new SimpleEntry<VKmer, ReadIdSet>(new VKmer(), new ReadIdSet());
+        createdEdge = null;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        createdEdge = null;
     }
 
     public Entry<VKmer, ReadIdSet> getCreatedEdge() {
+        if (createdEdge == null) {
+            createdEdge = new SimpleEntry<VKmer, ReadIdSet>(new VKmer(), new ReadIdSet());
+        }
         return createdEdge;
     }
 
     public void setCreatedEdge(VKmer createdKmer, ReadIdSet createdReadIds) {
-        validMessageFlag |= SPLITREPEAT_MESSAGE_FIELDS.CREATED_EDGE;
-        this.createdEdge = new SimpleEntry<VKmer, ReadIdSet>(createdKmer, createdReadIds);
+        createdEdge = new SimpleEntry<VKmer, ReadIdSet>(createdKmer, createdReadIds);
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
-        reset();
         super.readFields(in);
-        if ((validMessageFlag & SPLITREPEAT_MESSAGE_FIELDS.CREATED_EDGE) > 0) {
+        if ((messageFields & SPLITREPEAT_MESSAGE_FIELDS.CREATED_EDGE) != 0) {
             VKmer createdKmer = new VKmer();
             createdKmer.readFields(in);
             ReadIdSet createdReadIds = new ReadIdSet();
@@ -47,9 +54,18 @@ public class SplitRepeatMessage extends MessageWritable {
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
-        if ((validMessageFlag & SPLITREPEAT_MESSAGE_FIELDS.CREATED_EDGE) > 0) {
+        if (createdEdge != null) {
             createdEdge.getKey().write(out);
             createdEdge.getValue().write(out);
         }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (createdEdge != null) {
+            messageFields |= SPLITREPEAT_MESSAGE_FIELDS.CREATED_EDGE;
+        }
+        return messageFields;
     }
 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/SymmetryCheckerMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/SymmetryCheckerMessage.java
@@ -7,45 +7,58 @@ import java.io.IOException;
 import edu.uci.ics.genomix.type.EdgeMap;
 
 public class SymmetryCheckerMessage extends MessageWritable {
-    
-    class SYMMERTRYCHECKER_MESSAGE_FIELDS extends MESSAGE_FIELDS{
+
+    protected class SYMMERTRYCHECKER_MESSAGE_FIELDS extends MESSAGE_FIELDS {
         public static final byte EDGE_MAP = 1 << 1; // used in subclass: SymmetryCheckerMessage
     }
-    
+
     private EdgeMap edgeMap;
 
     public SymmetryCheckerMessage() {
         super();
-        edgeMap = new EdgeMap();
+        edgeMap = null;
     }
 
+    @Override
     public void reset() {
         super.reset();
-        edgeMap.clear();
+        edgeMap = null;
     }
 
     public EdgeMap getEdgeMap() {
+        if (edgeMap == null) {
+            edgeMap = new EdgeMap();
+        }
         return edgeMap;
     }
 
     public void setEdgeMap(EdgeMap edgeMap) {
-        validMessageFlag |= SYMMERTRYCHECKER_MESSAGE_FIELDS.EDGE_MAP;
-        this.edgeMap.clear();
-        this.edgeMap.putAll(edgeMap);
+        getEdgeMap().clear();
+        getEdgeMap().putAll(edgeMap);
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
-        reset();
         super.readFields(in);
-        if ((validMessageFlag & SYMMERTRYCHECKER_MESSAGE_FIELDS.EDGE_MAP) > 0)
-            edgeMap.readFields(in);
+        if ((messageFields & SYMMERTRYCHECKER_MESSAGE_FIELDS.EDGE_MAP) != 0) {
+            getEdgeMap().readFields(in);
+        }
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
-        if ((validMessageFlag & SYMMERTRYCHECKER_MESSAGE_FIELDS.EDGE_MAP) > 0)
+        if (edgeMap != null) {
             edgeMap.write(out);
+        }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (edgeMap != null) {
+            messageFields |= SYMMERTRYCHECKER_MESSAGE_FIELDS.EDGE_MAP;
+        }
+        return messageFields;
     }
 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/bubblemerge/SimpleBubbleMergeVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/bubblemerge/SimpleBubbleMergeVertex.java
@@ -64,6 +64,7 @@ public class SimpleBubbleMergeVertex extends DeBruijnGraphCleanVertex<VertexValu
         if (forwardNeighbor.kmer.equals(reverseNeighbor.kmer))
             throw new IllegalStateException("majorVertexId is equal to minorVertexId, this is not allowed!");
 
+        outgoingMsg.reset();
         VKmer minorVertexId;
         boolean forwardIsMajor = forwardNeighbor.kmer.compareTo(reverseNeighbor.kmer) >= 0;
         if (forwardIsMajor) {

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable.State;
 import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage;
+import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage.PATHMERGE_MESSAGE_FIELDS;
 import edu.uci.ics.genomix.pregelix.log.LogUtil;
 import edu.uci.ics.genomix.pregelix.operator.DeBruijnGraphCleanVertex;
 import edu.uci.ics.genomix.pregelix.type.MessageFlag.MESSAGETYPE;
@@ -135,6 +136,7 @@ public abstract class BasicPathMergeVertex<V extends VertexValueWritable, M exte
                         EdgeMap edgeMap = new EdgeMap();
                         edgeMap.put(iter.next(), vertex.getEdgeMap(updateEdge).get(dest));
                         outgoingMsg.getNode().setEdgeMap(newEdgetype, edgeMap); // copy into outgoingMsg
+                        outgoingMsg.validMessageFlag |= PATHMERGE_MESSAGE_FIELDS.NODE; // silly command to indicate that node has changed.
                         sendMsg(dest, outgoingMsg);
                     }
                 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/pathmerge/BasicPathMergeVertex.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable;
 import edu.uci.ics.genomix.pregelix.io.VertexValueWritable.State;
 import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage;
-import edu.uci.ics.genomix.pregelix.io.message.PathMergeMessage.PATHMERGE_MESSAGE_FIELDS;
 import edu.uci.ics.genomix.pregelix.log.LogUtil;
 import edu.uci.ics.genomix.pregelix.operator.DeBruijnGraphCleanVertex;
 import edu.uci.ics.genomix.pregelix.type.MessageFlag.MESSAGETYPE;
@@ -136,7 +135,6 @@ public abstract class BasicPathMergeVertex<V extends VertexValueWritable, M exte
                         EdgeMap edgeMap = new EdgeMap();
                         edgeMap.put(iter.next(), vertex.getEdgeMap(updateEdge).get(dest));
                         outgoingMsg.getNode().setEdgeMap(newEdgetype, edgeMap); // copy into outgoingMsg
-                        outgoingMsg.validMessageFlag |= PATHMERGE_MESSAGE_FIELDS.NODE; // silly command to indicate that node has changed.
                         sendMsg(dest, outgoingMsg);
                     }
                 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/BasicBFSTraverseVertex.java
@@ -123,6 +123,7 @@ public class BasicBFSTraverseVertex extends
             outgoingMsg.setDestReadHeadOrientation(firstReadHeadType);
         }
         outgoingMsg.setReadId(readId); // commonReadId
+        outgoingMsg.setTotalBFSLength(0); // this is the beginning of the search
 
         return srcNode;
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/ScaffoldingVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding/ScaffoldingVertex.java
@@ -196,10 +196,12 @@ public class ScaffoldingVertex extends BasicBFSTraverseVertex {
                 // setup ougoingMsg and prepare to sendMsg
                 outgoingMsg.reset();
 
-                // copy targetVertex
+                // copy unchanged details from incomingMsg
+                outgoingMsg.setSourceVertexId(incomingMsg.getSourceVertexId());
                 outgoingMsg.setTargetVertexId(incomingMsg.getTargetVertexId());
-                // copy commonReadId
                 outgoingMsg.setReadId(incomingMsg.getReadId());
+                outgoingMsg.setSrcReadHeadOrientation(incomingMsg.getSrcReadHeadOrientation());
+                outgoingMsg.setDestReadHeadOrientation(incomingMsg.getDestReadHeadOrientation());
                 // update totalBFSLength 
                 outgoingMsg.setTotalBFSLength(totalBFSLength);
 


### PR DESCRIPTION
@anbangx @JavierJia @Nan-Zhang 

Rather than using a byte to store what fields are in use in pregelix messages, this PR sets them all to `null` and transparently populates them when a `get()` is called.  This will work as long as any reused mesages are `.reset()`'ed.

This way of storing values is also safer since in some cases, trying to read from a value that has never been set will result in a NPE (only works for values that aren't automatically generated, such as primitive types and enums). This allowed me to find and fix 2 bugs in our pregelix code.

We could take this one step further and remove the automatic creation of the msg values.

This PR supersedes #53.
