### PR TITLE
bugfix for FR merge but w/ performance regression; test cases

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/VKmer.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/VKmer.java
@@ -533,6 +533,12 @@ public class VKmer extends BinaryComparable implements Serializable, WritableCom
         mergeWithFFKmer(kmerSize, new VKmer(kmer.toString()));
     }
 
+    public void mergeWithFRKmer(int initialKmerSize, VKmer kmer) {
+        VKmer revcomp = new VKmer();
+        revcomp.setReversedFromStringBytes(kmer.getKmerLetterLength(), kmer.toString().getBytes(), 0);
+        mergeWithFFKmer(initialKmerSize, revcomp);
+    }
+    
     /**
      * Merge Kmer with the next connected Kmer, when that Kmer needs to be
      * reverse-complemented e.g. AAGCTAA merge with GGTTGTT, if the initial
@@ -543,7 +549,7 @@ public class VKmer extends BinaryComparable implements Serializable, WritableCom
      * @param kmer
      *            : the next kmer
      */
-    public void mergeWithFRKmer(int initialKmerSize, VKmer kmer) {
+    public void mergeWithFRKmerOLD(int initialKmerSize, VKmer kmer) {
         if (lettersInKmer < initialKmerSize - 1 || kmer.lettersInKmer < initialKmerSize - 1) {
             throw new IllegalArgumentException("Not enough letters in the kmers to perform a merge! Tried K="
                     + initialKmerSize + ", merge '" + this + "' with '" + kmer + "'.");

--- a/genomix/genomix-data/src/test/java/edu/uci/ics/genomix/type/VKmerTest.java
+++ b/genomix/genomix-data/src/test/java/edu/uci/ics/genomix/type/VKmerTest.java
@@ -574,5 +574,40 @@ public class VKmerTest {
         Assert.assertEquals(kmer1.editDistance(kmer2), kmer2.editDistance(kmer1));
 
     }
+    
+    @Test
+    public void TestLargeKmerMergeFF() {
+        VKmer kmer1 = new VKmer("GCGTACGCAGGATAGT");
+        VKmer kmer2 = new VKmer("AGGATAGTATGTGAA");        
+        kmer1.mergeWithKmerInDir(EDGETYPE.FF, 9, kmer2);
+        Assert.assertEquals("Invalid FF merge!!!", "GCGTACGCAGGATAGTATGTGAA", kmer1.toString());
+    }
+    
+    @Test
+    public void TestLargeKmerMergeFR() {
+        VKmer kmer1 = new VKmer("GCGTACGCAGGATAGT");
+        VKmer kmer2 = new VKmer("TTCACATACTATCCT");
+        
+        kmer1.mergeWithKmerInDir(EDGETYPE.FR, 9, kmer2);
+        Assert.assertEquals("Invalid FR merge!!!", "GCGTACGCAGGATAGTATGTGAA", kmer1.toString());
+    }
+    
+    @Test
+    public void TestLargeKmerMergeRF() {
+        VKmer kmer1 = new VKmer("ACTATCCTGCGTACGC");
+        VKmer kmer2 = new VKmer("AGGATAGTATGTGAA");
+        
+        kmer1.mergeWithKmerInDir(EDGETYPE.RF, 9, kmer2);
+        Assert.assertEquals("Invalid RF merge!!!", "TTCACATACTATCCTGCGTACGC", kmer1.toString());
+    }
+    
+    @Test
+    public void TestLargeKmerMergeRR() {
+        VKmer kmer1 = new VKmer("ACTATCCTGCGTACGC");
+        VKmer kmer2 = new VKmer("TTCACATACTATCCT");
+        
+        kmer1.mergeWithKmerInDir(EDGETYPE.RR, 9, kmer2);
+        Assert.assertEquals("Invalid RR merge!!!", "TTCACATACTATCCTGCGTACGC", kmer1.toString());
+    }
 
 }


### PR DESCRIPTION
@anbangx @Nan-Zhang @JavierJia 
Hey guys,  I officially suck at bit twiddling.  Both FR and RF merges are currently just converting the other kmer to a string.  But! this fixes the indel and SNP problem we saw when doing tests (hooray!)

Any volunteers for going back and fixing this code?  (it's so ugly...)

Anyone? Bueller? 
