### PR TITLE
increase hardcoded pregelix framesize (tmp fix)

### DIFF
--- a/genomix/genomix-driver/src/main/resources/conf/cluster.properties
+++ b/genomix/genomix-driver/src/main/resources/conf/cluster.properties
@@ -31,7 +31,7 @@ CLASSPATH="${HADOOP_HOME}:${CLASSPATH}:."
 # The FRAME_SIZE is the size in bytes of a single "page" used in an external merge-sort.
 # The FRAME_LIMIT is the number of such pages to use in an in-memory sort buffer.
 # By default, we use 64k * 4096 = 268MB buffer.
-FRAME_SIZE=65535
+FRAME_SIZE=1048560
 FRAME_LIMIT=4096
 
 # The number of jobs to keep logs for (logs are kept in-memory)

--- a/pregelix/pregelix-dataflow/src/main/java/edu/uci/ics/pregelix/dataflow/context/RuntimeContext.java
+++ b/pregelix/pregelix-dataflow/src/main/java/edu/uci/ics/pregelix/dataflow/context/RuntimeContext.java
@@ -68,7 +68,7 @@ public class RuntimeContext implements IWorkspaceFileFactory {
         fileMapManager = new TransientFileMapManager();
         ICacheMemoryAllocator allocator = new HeapBufferAllocator();
         IPageReplacementStrategy prs = new ClockPageReplacementStrategy();
-        int pageSize = 64 * 1024 * 4;
+        int pageSize = 64 * 1024 * 4 * 4 * 4;
         long memSize = Runtime.getRuntime().maxMemory();
         long bufferSize = memSize / 4;
         int numPages = (int) (bufferSize / pageSize);


### PR DESCRIPTION
@anbangx @Nan-Zhang @JavierJia @Elmira88 
Hi all, if you're planning on running our pipeline on decently sized data and will be doing a lot of merging, you're going to need to make adjustments to the pregelix's hard-coded bufferCache pageSize.  Yingyi is working on a way to configure this, but for now just make a change similar to what  you see in the diff. 

This will solve problems that look like:

``` java
Caused by: edu.uci.ics.hyracks.storage.am.common.api.TreeIndexException: Space required for record (137070) larger than maximum acceptable size (131059)
```
