### PR TITLE
add version of tipremove that doesn't require graph compression

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/config/GenomixJobConf.java
@@ -168,8 +168,8 @@ public class GenomixJobConf extends JobConf {
         BUBBLE,
         BUBBLE_COMPLEX,
         LOW_COVERAGE,
-        TIP_REMOVE,
-        TIP_REMOVE_SEARCH,
+        TIP_SINGLE_NODE,
+        TIP,
         SCAFFOLD,
         SPLIT_REPEAT,
         DUMP_FASTA,
@@ -397,7 +397,7 @@ public class GenomixJobConf extends JobConf {
         if (get(PIPELINE_ORDER) == null) {
             set(PIPELINE_ORDER,
                     Patterns.stringFromArray(new Patterns[] { Patterns.BUILD, Patterns.MERGE, Patterns.LOW_COVERAGE,
-                            Patterns.MERGE, Patterns.TIP_REMOVE, Patterns.MERGE, Patterns.BUBBLE, Patterns.MERGE,
+                            Patterns.MERGE, Patterns.TIP_SINGLE_NODE, Patterns.MERGE, Patterns.BUBBLE, Patterns.MERGE,
                             Patterns.SPLIT_REPEAT, Patterns.MERGE, Patterns.SCAFFOLD, Patterns.MERGE }));
         }
 

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/config/GenomixJobConf.java
@@ -169,6 +169,7 @@ public class GenomixJobConf extends JobConf {
         BUBBLE_COMPLEX,
         LOW_COVERAGE,
         TIP_REMOVE,
+        TIP_REMOVE_SEARCH,
         SCAFFOLD,
         SPLIT_REPEAT,
         DUMP_FASTA,

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/EDGETYPE.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/type/EDGETYPE.java
@@ -7,7 +7,7 @@ import java.util.EnumSet;
 
 import org.apache.hadoop.io.Writable;
 
-public enum EDGETYPE implements Writable{ 
+public enum EDGETYPE implements Writable {
 
     FF((byte) (0b00)),
     FR((byte) (0b01)),
@@ -64,14 +64,14 @@ public enum EDGETYPE implements Writable{
                 throw new RuntimeException("Unrecognized direction in mirrorDirection: " + edgeType);
         }
     }
-    
+
     /**
      * 
      */
-    public static EDGETYPE getEdgeTypeFromDirToDir(DIR dir1, DIR dir2){
-        switch(dir1){
+    public static EDGETYPE getEdgeTypeFromDirToDir(DIR dir1, DIR dir2) {
+        switch (dir1) {
             case FORWARD:
-                switch(dir2){
+                switch (dir2) {
                     case FORWARD:
                         return FF;
                     case REVERSE:
@@ -80,7 +80,7 @@ public enum EDGETYPE implements Writable{
                         throw new IllegalArgumentException("Invalid direction2 given: " + dir2);
                 }
             case REVERSE:
-                switch(dir2){
+                switch (dir2) {
                     case FORWARD:
                         return RF;
                     case REVERSE:
@@ -92,17 +92,34 @@ public enum EDGETYPE implements Writable{
                 throw new IllegalArgumentException("Invalid direction1 given: " + dir2);
         }
     }
-    
+
     public DIR dir() {
         return dir(this);
     }
 
-    public static DIR dir(EDGETYPE edgeType) { // .dir static / non-static
+    public static DIR dir(EDGETYPE edgeType) {
         switch (edgeType) {
             case FF:
             case FR:
                 return DIR.FORWARD;
             case RF:
+            case RR:
+                return DIR.REVERSE;
+            default:
+                throw new RuntimeException("Unrecognized direction in dirFromEdgeType: " + edgeType);
+        }
+    }
+
+    public DIR neighborDir() {
+        return neighborDir(this);
+    }
+
+    public static DIR neighborDir(EDGETYPE edgeType) {
+        switch (edgeType) {
+            case FF:
+            case RF:
+                return DIR.FORWARD;
+            case FR:
             case RR:
                 return DIR.REVERSE;
             default:
@@ -230,4 +247,5 @@ public enum EDGETYPE implements Writable{
     public void readFields(DataInput in) throws IOException {
         this.val = in.readByte();
     }
+
 }

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -116,10 +116,10 @@ public class GenomixDriver {
             case UNROLL_TANDEM:
                 pregelixJobs.add(UnrollTandemRepeat.getConfiguredJob(conf, UnrollTandemRepeat.class));
                 break;
-            case TIP_REMOVE:
+            case TIP_SINGLE_NODE:
                 pregelixJobs.add(TipRemoveVertex.getConfiguredJob(conf, TipRemoveVertex.class));
                 break;
-            case TIP_REMOVE_SEARCH:
+            case TIP:
                 pregelixJobs.add(TipRemoveWithSearchVertex.getConfiguredJob(conf, TipRemoveWithSearchVertex.class));
                 break;
             case BUBBLE:

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -53,6 +53,7 @@ import edu.uci.ics.genomix.pregelix.operator.removelowcoverage.RemoveLowCoverage
 import edu.uci.ics.genomix.pregelix.operator.scaffolding.ScaffoldingVertex;
 import edu.uci.ics.genomix.pregelix.operator.splitrepeat.SplitRepeatVertex;
 import edu.uci.ics.genomix.pregelix.operator.tipremove.TipRemoveVertex;
+import edu.uci.ics.genomix.pregelix.operator.tipremove.TipRemoveWithSearchVertex;
 import edu.uci.ics.genomix.pregelix.operator.unrolltandemrepeat.UnrollTandemRepeat;
 import edu.uci.ics.genomix.pregelix.testhelper.BFSTraverseVertex;
 import edu.uci.ics.genomix.pregelix.testhelper.BridgeAddVertex;
@@ -117,6 +118,9 @@ public class GenomixDriver {
                 break;
             case TIP_REMOVE:
                 pregelixJobs.add(TipRemoveVertex.getConfiguredJob(conf, TipRemoveVertex.class));
+                break;
+            case TIP_REMOVE_SEARCH:
+                pregelixJobs.add(TipRemoveWithSearchVertex.getConfiguredJob(conf, TipRemoveWithSearchVertex.class));
                 break;
             case BUBBLE:
                 pregelixJobs.add(SimpleBubbleMergeVertex.getConfiguredJob(conf, SimpleBubbleMergeVertex.class));

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/TipRemoveWithSearchMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/TipRemoveWithSearchMessage.java
@@ -37,23 +37,23 @@ public class TipRemoveWithSearchMessage extends MessageWritable {
         return visitedNodes;
     }
 
-    public void setPreviousNodes(VKmerList previousNodes) {
-        if (previousNodes == null || previousNodes.size() == 0) {
+    public void setVisitedNodes(VKmerList visitedNodes) {
+        if (visitedNodes == null || visitedNodes.size() == 0) {
             this.visitedNodes = null;
         } else {
-            getVisitedNodes().setCopy(previousNodes);
+            getVisitedNodes().setCopy(visitedNodes);
         }
     }
 
     protected static class TIP_REMOVE_FIELDS extends MESSAGE_FIELDS {
-        public static final byte PREVIOUS_NODES = 1 << 1;
+        public static final byte VISITED_NODES = 1 << 1;
     }
 
     @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         visitedLength = in.readInt();
-        if ((messageFields & TIP_REMOVE_FIELDS.PREVIOUS_NODES) != 0) {
+        if ((messageFields & TIP_REMOVE_FIELDS.VISITED_NODES) != 0) {
             getVisitedNodes().readFields(in);
         }
     }
@@ -71,7 +71,7 @@ public class TipRemoveWithSearchMessage extends MessageWritable {
     protected byte getActiveMessageFields() {
         byte messageFields = super.getActiveMessageFields();
         if (visitedNodes != null && visitedNodes.size() != 0) {
-            messageFields |= TIP_REMOVE_FIELDS.PREVIOUS_NODES;
+            messageFields |= TIP_REMOVE_FIELDS.VISITED_NODES;
         }
         return messageFields;
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/TipRemoveWithSearchMessage.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/io/message/TipRemoveWithSearchMessage.java
@@ -1,0 +1,86 @@
+package edu.uci.ics.genomix.pregelix.io.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import edu.uci.ics.genomix.type.Kmer;
+import edu.uci.ics.genomix.type.Node;
+import edu.uci.ics.genomix.type.VKmerList;
+
+public class TipRemoveWithSearchMessage extends MessageWritable {
+    private int visitedLength = 0;
+    private VKmerList visitedNodes = null;
+    
+    /** Include the given node in incomingMsg's path of vertices
+     * 
+     * @param v   the vertex to add to incomingMsg's path
+     * @param incomingMsg
+     */
+    public void visitNode(Node n) {
+        visitedLength += n.getKmerLength() - Kmer.getKmerLength() + 1;
+        getVisitedNodes().append(n.getInternalKmer());
+    }
+    
+    public int getVisitedLength() {
+        return visitedLength;
+    }
+
+    public void setVisitedLength(int visitedLength) {
+        this.visitedLength = visitedLength;
+    }
+
+    public VKmerList getVisitedNodes() {
+        if (visitedNodes == null) {
+            visitedNodes = new VKmerList();
+        }
+        return visitedNodes;
+    }
+
+    public void setPreviousNodes(VKmerList previousNodes) {
+        if (previousNodes == null || previousNodes.size() == 0) {
+            this.visitedNodes = null;
+        } else {
+            getVisitedNodes().setCopy(previousNodes);
+        }
+    }
+
+    protected static class TIP_REMOVE_FIELDS extends MESSAGE_FIELDS {
+        public static final byte PREVIOUS_NODES = 1 << 1;
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        visitedLength = in.readInt();
+        if ((messageFields & TIP_REMOVE_FIELDS.PREVIOUS_NODES) != 0) {
+            getVisitedNodes().readFields(in);
+        }
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+        out.writeInt(visitedLength);
+        if (visitedNodes != null && visitedNodes.size() != 0) {
+            visitedNodes.write(out);
+        }
+    }
+
+    @Override
+    protected byte getActiveMessageFields() {
+        byte messageFields = super.getActiveMessageFields();
+        if (visitedNodes != null && visitedNodes.size() != 0) {
+            messageFields |= TIP_REMOVE_FIELDS.PREVIOUS_NODES;
+        }
+        return messageFields;
+    }
+    
+    @Override 
+    public void reset() {
+        super.reset();
+        visitedNodes = null;
+        visitedLength = 0;
+    }
+
+}

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
@@ -1,0 +1,140 @@
+package edu.uci.ics.genomix.pregelix.operator.tipremove;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.logging.Logger;
+
+import edu.uci.ics.genomix.config.GenomixJobConf;
+import edu.uci.ics.genomix.pregelix.io.VertexValueWritable;
+import edu.uci.ics.genomix.pregelix.io.message.TipRemoveWithSearchMessage;
+import edu.uci.ics.genomix.pregelix.operator.DeBruijnGraphCleanVertex;
+import edu.uci.ics.genomix.type.DIR;
+import edu.uci.ics.genomix.type.EDGETYPE;
+import edu.uci.ics.genomix.type.Node;
+import edu.uci.ics.genomix.type.VKmer;
+import edu.uci.ics.genomix.type.VKmerList;
+
+/**
+ * Remove tip or single node when kmerLength < MIN_LENGTH_TO_KEEP
+ * Details: Sequencing errors at the ends of the reads form "tips": short, low coverage nodes
+ * with in-degree + out-degree = 1 (they either have a single edge in or a single edge out).
+ * The algorithm identifies these nodes and prunes them from the graph. This is then followed
+ * by recompressing the graph.
+ * 
+ * This variant of the algorithm can identify tips in an uncompressed graph 
+ */
+public class TipRemoveWithSearchVertex extends
+        DeBruijnGraphCleanVertex<VertexValueWritable, TipRemoveWithSearchMessage> {
+
+    private static final Logger LOG = Logger.getLogger(TipRemoveWithSearchVertex.class.getName());
+
+    private int MIN_LENGTH_TO_KEEP = -1;
+
+    @Override
+    public void compute(Iterator<TipRemoveWithSearchMessage> msgIterator) {
+        if (getSuperstep() == 1) {
+            initVertex();
+            msgIterator = initiateTipSearch();
+        }
+        processSearch(msgIterator);
+        voteToHalt();
+    }
+
+    @Override
+    public void initVertex() {
+        super.initVertex();
+        if (MIN_LENGTH_TO_KEEP == -1) {
+            MIN_LENGTH_TO_KEEP = Integer.parseInt(getContext().getConfiguration().get(
+                    GenomixJobConf.TIP_REMOVE_MAX_LENGTH));
+        }
+    }
+
+    /**
+     * simulate an incoming tip msg if this is a tip. this lets us call the processSearch function in each iteration
+     */
+    public Iterator<TipRemoveWithSearchMessage> initiateTipSearch() {
+        Node node = getVertexValue();
+        ArrayList<TipRemoveWithSearchMessage> tipMsgs = new ArrayList<TipRemoveWithSearchMessage>();
+        if (node.degree(DIR.FORWARD) == 0) {
+            TipRemoveWithSearchMessage tipMsg = new TipRemoveWithSearchMessage();
+            tipMsg.setFlag(EDGETYPE.RR.get());
+            tipMsgs.add(tipMsg);
+        } else if (node.degree(DIR.REVERSE) == 0) {
+            TipRemoveWithSearchMessage tipMsg = new TipRemoveWithSearchMessage();
+            tipMsg.setFlag(EDGETYPE.FF.get());
+            tipMsgs.add(tipMsg);
+        }
+        return tipMsgs.iterator();
+    }
+
+    public void processSearch(Iterator<TipRemoveWithSearchMessage> msgIterator) {
+        Node node = getVertexValue();
+        TipRemoveWithSearchMessage incomingMsg;
+        boolean stop;
+        EDGETYPE inET;
+        DIR toPrevDir;
+        DIR outDir;
+        while (msgIterator.hasNext()) {
+            incomingMsg = msgIterator.next();
+            inET = EDGETYPE.fromByte(incomingMsg.getFlag());
+            outDir = inET.neighborDir(); // way I'd leave this node
+            toPrevDir = outDir.mirror(); // direction towards last visited node
+            if (node.degree(toPrevDir) > 1) {
+                // reached node which has multiple incoming edges (where B is origin  ...A<__B)
+                // stop the search without considering this node
+                stop = true;
+            } else if (node.degree(outDir) > 1) {
+                // reached a node with multiple paths leading out of this node  (where B is origin  ...>A----B)
+                // this is NOT a tip! must drop this message
+                continue;
+            } else if (node.degree(outDir) == 0) {
+                // no longer a path in this direction; stop at this node  ( A----B ) 
+                stop = true;
+                incomingMsg.visitNode(node);
+            } else {
+                // a simple path node; continue the search
+                stop = false;
+                incomingMsg.visitNode(node);
+            }
+            if (stop) {
+                if (incomingMsg.getVisitedLength() < MIN_LENGTH_TO_KEEP) {
+                    deleteVisitedNodes(incomingMsg);
+                }
+            } else {
+                continueSearch(outDir, incomingMsg);
+            }
+        }
+    }
+
+    private void deleteVisitedNodes(TipRemoveWithSearchMessage msg) {
+        Node node = getVertexValue();
+        EDGETYPE inET = EDGETYPE.fromByte(msg.getFlag());
+        VKmerList visitedNodes = msg.getVisitedNodes();
+        if (visitedNodes.size() == 0) {
+            return;
+        }
+        for (VKmer id : visitedNodes) {
+            deleteVertex(id);
+        }
+        // the last visited node is either me or I have a dangling edge to it
+        // if it's not me, remove the edge
+        VKmer lastVisited = visitedNodes.getPosition(visitedNodes.size() - 1);
+        if (!lastVisited.equals(getVertexId())) {
+            // I am not in the path but have an edge towards the deleted node
+            node.getEdgeMap(inET.mirror()).remove(lastVisited);
+        }
+    }
+
+    private void continueSearch(DIR outDir, TipRemoveWithSearchMessage msg) {
+        Node node = getVertexValue();
+        if (node.degree(outDir) != 1) {
+            throw new IllegalStateException("Should have degree == 1 in " + outDir + ". I am " + node);
+        }
+        for (EDGETYPE outET : outDir.edgeTypes()) {
+            for (VKmer id : node.getEdgeMap(outET).keySet()) {
+                msg.setFlag(outET.get());
+                sendMsg(id, msg);
+            }
+        }
+    }
+}

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
@@ -96,12 +96,13 @@ public class TipRemoveWithSearchVertex extends
                 stop = false;
                 incomingMsg.visitNode(node);
             }
-            if (stop) {
-                if (incomingMsg.getVisitedLength() < MIN_LENGTH_TO_KEEP) {
+            
+            if (incomingMsg.getVisitedLength() < MIN_LENGTH_TO_KEEP) {
+                if (stop) {
                     deleteVisitedNodes(incomingMsg);
+                } else {
+                    continueSearch(outDir, incomingMsg);
                 }
-            } else {
-                continueSearch(outDir, incomingMsg);
             }
         }
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/tipremove/TipRemoveWithSearchVertex.java
@@ -28,7 +28,7 @@ public class TipRemoveWithSearchVertex extends
 
     private static final Logger LOG = Logger.getLogger(TipRemoveWithSearchVertex.class.getName());
 
-    private int MIN_LENGTH_TO_KEEP = -1;
+    private static int MIN_LENGTH_TO_KEEP = -1;
 
     @Override
     public void compute(Iterator<TipRemoveWithSearchMessage> msgIterator) {
@@ -80,11 +80,11 @@ public class TipRemoveWithSearchVertex extends
             outDir = inET.neighborDir(); // way I'd leave this node
             toPrevDir = outDir.mirror(); // direction towards last visited node
             if (node.degree(toPrevDir) > 1) {
-                // reached node which has multiple incoming edges (where B is origin  ...A<__B)
+                // reached node A which has multiple incoming edges (where B is origin  ...A<__B)
                 // stop the search without considering this node
                 stop = true;
             } else if (node.degree(outDir) > 1) {
-                // reached a node with multiple paths leading out of this node  (where B is origin  ...>A----B)
+                // reached node A with multiple paths leading out of this node  (where B is origin  ...>A----B)
                 // this is NOT a tip! must drop this message
                 continue;
             } else if (node.degree(outDir) == 0) {


### PR DESCRIPTION
@anbangx take a look.  This version implements TIP_REMOVE in an uncompressed graph.  I'm going to do some timing on it but I thought you'd want to have a look.

There is one slight difference in this version vs. the previous tip remove: since there may be several tip searches in the graph happening simultaneously, the actual behavior is slightly different.  One tip can be removed before another tip so the second tip, if longer, may not be removed when in the original it would be.  For example:

```
             _____C
...A------B<
             ---------------------D
```

Both C and D would be tip in the compressed graph and would be removed, leaving only `A-----B`.  In our case, there's a chance that C will be removed first, which will make D look longer than it did in the compressed graph.
