### PR TITLE
bubble merge uses max distance

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
@@ -384,7 +384,7 @@ public class GenomixJobConf extends JobConf {
             setInt(BRIDGE_REMOVE_MAX_LENGTH, kmerLength + 1);
 
         if (getFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, -1) == -1)
-            setFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, .5f);
+            setFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, .05f);
 
         if (getInt(BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH, -1) == -1)
             setInt(BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH, kmerLength * 2);

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
@@ -85,6 +85,9 @@ public class GenomixJobConf extends JobConf {
 
         @Option(name = "-bubbleMerge_maxDissimilarity", usage = "Maximum dissimilarity (1 - % identity) allowed between two kmers while still considering them a \"bubble\", (leading to their collapse into a single node)", required = false)
         private float bubbleMerge_maxDissimilarity = -1;
+        
+        @Option(name = "-bubbleMerge_maxLength", usage = "The maximum length an internal node may be and still be considered a bubble", required = false)
+        private int bubbleMerge_maxLength;
 
         @Option(name = "-bubbleMergewithsearch_maxLength", usage = "Maximum length can be searched", required = false)
         private int bubbleMergeWithSearch_maxLength = -1;
@@ -165,6 +168,7 @@ public class GenomixJobConf extends JobConf {
 
         @Option(name = "-runAllStats", usage = "Whether or not to run a STATS job after each normal job")
         private boolean runAllStats = false;
+
     }
 
     /**
@@ -262,6 +266,7 @@ public class GenomixJobConf extends JobConf {
     // Graph cleaning   
     public static final String BRIDGE_REMOVE_MAX_LENGTH = "genomix.bridgeRemove.maxLength";
     public static final String BUBBLE_MERGE_MAX_DISSIMILARITY = "genomix.bubbleMerge.maxDissimilarity";
+    public static final String BUBBLE_MERGE_MAX_LENGTH = "genomix.bubbleMerge.maxLength";
     public static final String BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH = "genomix.bubbleMergeWithSearch.maxSearchLength";
     public static final String BUBBLE_MERGE_WITH_SEARCH_SEARCH_DIRECTION = "genomix.bubbleMergeWithSearch.searchDirection";
     public static final String GRAPH_CLEAN_MAX_ITERATIONS = "genomix.graphClean.maxIterations";
@@ -385,6 +390,9 @@ public class GenomixJobConf extends JobConf {
 
         if (getFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, -1) == -1)
             setFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, .05f);
+        
+        if (getInt(BUBBLE_MERGE_MAX_LENGTH, -1) == -1)
+            setInt(BUBBLE_MERGE_MAX_LENGTH, kmerLength * 5);
 
         if (getInt(BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH, -1) == -1)
             setInt(BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH, kmerLength * 2);
@@ -494,6 +502,7 @@ public class GenomixJobConf extends JobConf {
         // Graph cleaning
         setInt(BRIDGE_REMOVE_MAX_LENGTH, opts.bridgeRemove_maxLength);
         setFloat(BUBBLE_MERGE_MAX_DISSIMILARITY, opts.bubbleMerge_maxDissimilarity);
+        setInt(BUBBLE_MERGE_MAX_LENGTH, opts.bubbleMerge_maxLength);
         setInt(BUBBLE_MERGE_WITH_SEARCH_MAX_LENGTH, opts.bubbleMergeWithSearch_maxLength);
         if (opts.bubbleMergeWithSearch_searchDirection != null)
             set(BUBBLE_MERGE_WITH_SEARCH_SEARCH_DIRECTION, opts.bubbleMergeWithSearch_searchDirection);

--- a/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/buildgraph/GenomixMapper.java
+++ b/genomix/genomix-hadoop/src/main/java/edu/uci/ics/genomix/hadoop/buildgraph/GenomixMapper.java
@@ -82,7 +82,8 @@ public class GenomixMapper extends MapReduceBase implements Mapper<LongWritable,
             mate1GeneLine = rawLine[2];
         } else {
             throw new IllegalStateException(
-                    "input format is not true! only support id'\t'readSeq'\t'mateReadSeq or id'\t'readSeq'");
+                    "input format is incorrect! only support id'\t'readSeq'\t'mateReadSeq or id'\t'readSeq' but saw"
+                    + value.toString() + "which has " + value.toString().split("\\t").length + " elements");
         }
 
         Pattern genePattern = Pattern.compile("[AGCT]+");

--- a/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/ReadsKeyValueParserFactory.java
+++ b/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/ReadsKeyValueParserFactory.java
@@ -98,7 +98,9 @@ public class ReadsKeyValueParserFactory implements IKeyValueParserFactory<LongWr
                     mate1GeneLine = rawLine[2];
                 } else {
                     throw new IllegalStateException(
-                            "input format is not true! only support id'\t'readSeq'\t'mateReadSeq or id'\t'readSeq'");
+                            "input format is not true! only support id'\t'readSeq'\t'mateReadSeq or id'\t'readSeq' but saw"
+                                    + value.toString() + "which has " + value.toString().split("\\t").length
+                                    + " elements");
                 }
 
                 Pattern genePattern = Pattern.compile("[AGCT]+");

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/simplebubblemerge/SimpleBubbleMergeVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/simplebubblemerge/SimpleBubbleMergeVertex.java
@@ -23,7 +23,8 @@ public class SimpleBubbleMergeVertex extends DeBruijnGraphCleanVertex<VertexValu
 
     private static final Logger LOG = Logger.getLogger(SimpleBubbleMergeVertex.class.getName());
 
-    private float DISSIMILAR_THRESHOLD = -1;
+    private float MAX_DISSIMILARITY = -1;
+    private int MAX_LENGTH = -1;
 
     private Map<VKmer, ArrayList<SimpleBubbleMergeMessage>> receivedMsgMap = new HashMap<VKmer, ArrayList<SimpleBubbleMergeMessage>>();
     private ArrayList<SimpleBubbleMergeMessage> receivedMsgList = new ArrayList<SimpleBubbleMergeMessage>();
@@ -36,9 +37,12 @@ public class SimpleBubbleMergeVertex extends DeBruijnGraphCleanVertex<VertexValu
     @Override
     public void initVertex() {
         super.initVertex();
-        if (DISSIMILAR_THRESHOLD < 0)
-            DISSIMILAR_THRESHOLD = Float.parseFloat(getContext().getConfiguration().get(
+        if (MAX_DISSIMILARITY < 0)
+            MAX_DISSIMILARITY = Float.parseFloat(getContext().getConfiguration().get(
                     GenomixJobConf.BUBBLE_MERGE_MAX_DISSIMILARITY));
+        if (MAX_LENGTH < 0) 
+            MAX_LENGTH = Integer.parseInt(getContext().getConfiguration().get(
+                    GenomixJobConf.BUBBLE_MERGE_MAX_LENGTH));
         if (outgoingMsg == null)
             outgoingMsg = new SimpleBubbleMergeMessage();
     }
@@ -120,8 +124,7 @@ public class SimpleBubbleMergeVertex extends DeBruijnGraphCleanVertex<VertexValu
 
                 //compute the dissimilarity
                 float fractionDissimilar = topMsg.computeDissimilar(curMsg); // TODO change to simmilarity everywhere
-
-                if (fractionDissimilar <= DISSIMILAR_THRESHOLD) { //if similar with top node, delete this node
+                if (fractionDissimilar <= MAX_DISSIMILARITY) { //if similar with top node, delete this node
                     topChanged = true;
                     boolean sameOrientation = topMsg.sameOrientation(curMsg);
                     // 1. add coverage to top node -- for unchangedSet
@@ -149,7 +152,8 @@ public class SimpleBubbleMergeVertex extends DeBruijnGraphCleanVertex<VertexValu
      */
     public void detectBubble() {
         VertexValueWritable vertex = getVertexValue();
-        if (vertex.degree(DIR.REVERSE) == 1 && vertex.degree(DIR.FORWARD) == 1) {
+        if (vertex.degree(DIR.REVERSE) == 1 && vertex.degree(DIR.FORWARD) == 1
+                && vertex.getInternalKmer().getKmerLetterLength() < MAX_LENGTH) {
             // send bubble and major vertex msg to minor vertex 
             sendBubbleAndMajorVertexMsgToMinorVertex();
         }


### PR DESCRIPTION
@anbangx 
Some bubbles in bubble merge were super-long.  Our default is now `K * 5`.  This also changes the max dissimilarity to 5% instead of 50%(!!).
