### PR TITLE
add configure(conf) to pregelix API, called once per iteration

### DIFF
--- a/pregelix/pregelix-api/src/main/java/edu/uci/ics/pregelix/api/graph/Vertex.java
+++ b/pregelix/pregelix-api/src/main/java/edu/uci/ics/pregelix/api/graph/Vertex.java
@@ -612,6 +612,17 @@ public abstract class Vertex<I extends WritableComparable, V extends Writable, E
         Vertex vertex = (Vertex) object;
         return vertexId.equals(vertex.getVertexId());
     }
+    
+    /**
+     * called *once* per partition at the start of each iteration, 
+     * before calls to open() or compute()
+     *  
+     * Users can override this method to configure the pregelix job 
+     * and vertex state. 
+     */
+    public void configure(Configuration conf) {
+
+    }
 
     /**
      * called immediately before invocations of compute() on a vertex

--- a/pregelix/pregelix-runtime/src/main/java/edu/uci/ics/pregelix/runtime/function/ComputeUpdateFunctionFactory.java
+++ b/pregelix/pregelix-runtime/src/main/java/edu/uci/ics/pregelix/runtime/function/ComputeUpdateFunctionFactory.java
@@ -107,6 +107,7 @@ public class ComputeUpdateFunctionFactory implements IUpdateFunctionFactory {
             private final List<ArrayTupleBuilder> tbs = new ArrayList<ArrayTupleBuilder>();
             private Configuration conf;
             private boolean dynamicStateLength;
+            private boolean userConfigured;
 
             @Override
             public void open(IHyracksTaskContext ctx, RecordDescriptor rd, IFrameWriter... writers)
@@ -115,6 +116,7 @@ public class ComputeUpdateFunctionFactory implements IUpdateFunctionFactory {
                 //LSM index does not have in-place update
                 this.dynamicStateLength = BspUtils.getDynamicVertexValueSize(conf) || BspUtils.useLSM(conf);
                 this.aggregators = BspUtils.createGlobalAggregators(conf);
+                this.userConfigured = false;
                 for (int i = 0; i < aggregators.size(); i++) {
                     this.aggregators.get(i).init();
                 }
@@ -195,6 +197,10 @@ public class ComputeUpdateFunctionFactory implements IUpdateFunctionFactory {
                 }
 
                 try {
+                    if (!userConfigured) {
+                        vertex.configure(conf);
+                        userConfigured = true;
+                    }
                     if (msgContentList.segmentStart()) {
                         vertex.open();
                     }


### PR DESCRIPTION
@anbangx @Elmira88 @JavierJia @Nan-Zhang 
This commit was just pushed to @sigmod as a change in the pregelix API.  It will allow us to replace all our initVertex() stuff with just the `configure(conf)` function, which will be called once per iteration (not once per iteration per vertex like compute() and open() are).

Let's clean up the initVertex() code all over the place and push the updates to this branch.
