### PR TITLE
Wbiesing/readheadset uses static configuration

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
@@ -622,7 +622,7 @@ public class GenomixJobConf extends JobConf {
     public static void setGlobalStaticConstants(Configuration conf) throws IOException {
         Kmer.setGlobalKmerLength(Integer.parseInt(conf.get(KMER_LENGTH)));
         //        ExternalableTreeSet.setupManager(conf, new Path(conf.get("hadoop.tmp.dir", "/tmp")));
-        ExternalableTreeSet.setupManager(conf, new Path("/user/tmp"));
+        ExternalableTreeSet.setupManager(conf, new Path("tmp"));
         ExternalableTreeSet.setCountLimit(1000);
 
         if (conf.get(READ_LENGTHS) != null) {

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/Node.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/Node.java
@@ -853,10 +853,4 @@ public class Node implements Writable, Serializable {
         int length = getKmerLength() == 0 ? Kmer.getKmerLength() : getKmerLength(); 
         return length * (getUnflippedReadIds().size() + getFlippedReadIds().size());
     }
-
-    
-    public void forceWriteEntireBody(boolean entire) {
-        unflippedReadIds.forceWriteEntireBody(entire);
-        flippedReadIds.forceWriteEntireBody(entire);
-    }
 }

--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/ReadHeadSet.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/ReadHeadSet.java
@@ -130,9 +130,4 @@ public class ReadHeadSet extends ExternalableTreeSet<ReadHeadInfo> {
         t.write(out);
     }
 
-    public void forceWriteEntireBody(boolean entire) {
-        super.forceWriteEntireBody(entire);
-
-    }
-
 }

--- a/genomix/genomix-data/src/test/java/edu/uci/ics/genomix/data/types/ExternalableTreeSetTest.java
+++ b/genomix/genomix-data/src/test/java/edu/uci/ics/genomix/data/types/ExternalableTreeSetTest.java
@@ -142,7 +142,7 @@ public class ExternalableTreeSetTest implements Serializable {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream w = new DataOutputStream(baos);
         try {
-            eSetA.forceWriteEntireBody(entire);
+            ExternalableTreeSet.forceWriteEntireBody(entire);
             eSetA.write(w);
         } catch (IOException e) {
             e.printStackTrace();
@@ -152,7 +152,6 @@ public class ExternalableTreeSetTest implements Serializable {
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         ExternalableTreeSet<TestIntWritable> eSetB = new TestExternalableTreeSet(local);
         try {
-            eSetB.forceReadEntireBody(entire);
             eSetB.readFields(new DataInputStream(bais));
         } catch (IOException e) {
             e.printStackTrace();
@@ -209,6 +208,7 @@ public class ExternalableTreeSetTest implements Serializable {
         }
 
         try {
+            ExternalableTreeSet.manager = null;
             ExternalableTreeSet.setupManager(conf, tmpPath);
         } catch (IOException e) {
             e.printStackTrace();
@@ -228,6 +228,7 @@ public class ExternalableTreeSetTest implements Serializable {
         ExternalableTreeSet.setCountLimit(limit);
 
         try {
+            ExternalableTreeSet.manager = null;
             ExternalableTreeSet.setupManager(conf, null);
         } catch (IOException e) {
             e.printStackTrace();
@@ -244,6 +245,7 @@ public class ExternalableTreeSetTest implements Serializable {
         ExternalableTreeSet.setCountLimit(limit);
 
         try {
+            ExternalableTreeSet.manager = null;
             ExternalableTreeSet.setupManager(conf, null);
         } catch (IOException e) {
             e.printStackTrace();

--- a/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/AggregateKmerAggregateFactory.java
+++ b/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/AggregateKmerAggregateFactory.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.mapred.JobConf;
 import edu.uci.ics.genomix.data.config.GenomixJobConf;
 import edu.uci.ics.genomix.data.types.EDGETYPE;
 import edu.uci.ics.genomix.data.types.Node;
+import edu.uci.ics.genomix.data.types.ReadHeadSet;
 import edu.uci.ics.hyracks.api.comm.IFrameTupleAccessor;
 import edu.uci.ics.hyracks.api.comm.IFrameWriter;
 import edu.uci.ics.hyracks.api.context.IHyracksTaskContext;
@@ -61,6 +62,7 @@ public class AggregateKmerAggregateFactory implements IAggregatorDescriptorFacto
             e2.printStackTrace();
             throw new HyracksDataException(e2);
         }
+        ReadHeadSet.forceWriteEntireBody(true);
 
         return new IAggregatorDescriptor() {
 
@@ -205,7 +207,7 @@ public class AggregateKmerAggregateFactory implements IAggregatorDescriptorFacto
                                 + "\nNode is:" + localUniNode.toString());
                     }
                 } catch (IOException e) {
-                    throw new HyracksDataException("I/O exception when writing aggregation to the output buffer.");
+                    throw new HyracksDataException("I/O exception when writing aggregation to the output buffer.", e);
                 }
 
                 return true; // FIXME the API doesn't specify what this is supposed to return... 

--- a/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/ReadsKeyValueParserFactory.java
+++ b/genomix/genomix-hyracks/src/main/java/edu/uci/ics/genomix/hyracks/graph/dataflow/ReadsKeyValueParserFactory.java
@@ -31,6 +31,7 @@ import edu.uci.ics.genomix.data.types.EDGETYPE;
 import edu.uci.ics.genomix.data.types.Kmer;
 import edu.uci.ics.genomix.data.types.Node;
 import edu.uci.ics.genomix.data.types.ReadHeadInfo;
+import edu.uci.ics.genomix.data.types.ReadHeadSet;
 import edu.uci.ics.genomix.data.types.VKmer;
 import edu.uci.ics.hyracks.api.comm.IFrameWriter;
 import edu.uci.ics.hyracks.api.context.IHyracksTaskContext;
@@ -75,6 +76,7 @@ public class ReadsKeyValueParserFactory implements IKeyValueParserFactory<LongWr
             e1.printStackTrace();
             throw new HyracksDataException(e1);
         }
+        ReadHeadSet.forceWriteEntireBody(true);
 
         return new IKeyValueParser<LongWritable, Text>() {
 

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/base/GenericVertexToNodeOutputFormat.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/base/GenericVertexToNodeOutputFormat.java
@@ -8,6 +8,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 import edu.uci.ics.genomix.data.types.Kmer;
 import edu.uci.ics.genomix.data.types.Node;
+import edu.uci.ics.genomix.data.types.ReadHeadSet;
 import edu.uci.ics.genomix.data.types.VKmer;
 import edu.uci.ics.pregelix.api.graph.Vertex;
 import edu.uci.ics.pregelix.api.io.VertexWriter;
@@ -32,6 +33,7 @@ public abstract class GenericVertexToNodeOutputFormat<V extends Node> extends
         public BinaryLoadGraphVertexWriter(RecordWriter<VKmer, Node> lineRecordWriter) {
             super(lineRecordWriter);
             node = new Node();
+            ReadHeadSet.forceWriteEntireBody(true);
         }
 
         @Override
@@ -44,7 +46,6 @@ public abstract class GenericVertexToNodeOutputFormat<V extends Node> extends
             if (node.getInternalKmer().getKmerLetterLength() == Kmer.getKmerLength()) {
                 node.setInternalKmer(null);
             }
-            node.forceWriteEntireBody(true);
             getRecordWriter().write(vertex.getVertexId(), node);
         }
     }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/base/NodeToGenericVertexInputFormat.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/base/NodeToGenericVertexInputFormat.java
@@ -6,6 +6,7 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 
 import edu.uci.ics.genomix.data.types.Node;
+import edu.uci.ics.genomix.data.types.ReadHeadSet;
 import edu.uci.ics.genomix.data.types.VKmer;
 import edu.uci.ics.pregelix.api.graph.Vertex;
 import edu.uci.ics.pregelix.api.util.BspUtils;
@@ -21,6 +22,8 @@ public abstract class NodeToGenericVertexInputFormat<V extends VertexValueWritab
 
         public BinaryDataCleanLoadGraphReader(RecordReader<VKmer, Node> recordReader) {
             super(recordReader);
+            // from HDFS, read complete records; within pregelix jobs, writes are chunked
+            ReadHeadSet.forceWriteEntireBody(false);
         }
 
         @Override


### PR DESCRIPTION
@anbangx @JavierJia 

We can't rely on any transient member variables staying intact since all classes are created via reflection and `newInstance`.  As a result, the `forceReadEntireBody` and `write*` changes were being lost.

This PR changes those values in two ways: 
- puts the `readEntireBody` flag into the `readFields` stream rather than some configuration.  Otherwise, it's impossible to know how the _previous_ `write` stored the ReadHeadSet.
- makes the `writeEntireBody` a static configuration parameter which is now set inside of the BUILD_HYRACKS code and in the pregelix vertex input and output format adapters.
