### PR TITLE
change fs.create everytime to avoid the fs.close exception

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/ExternalableTreeSet.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/types/ExternalableTreeSet.java
@@ -8,13 +8,14 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
@@ -30,7 +31,7 @@ public abstract class ExternalableTreeSet<T extends WritableComparable<T> & Seri
      */
     private static final long serialVersionUID = 1L;
     static FileManager manager;
-//    static private int countLimit = Integer.MAX_VALUE;
+    //    static private int countLimit = Integer.MAX_VALUE;
     static private int countLimit = 1000;
 
     public static synchronized void setupManager(Configuration conf, Path workPath) throws IOException {
@@ -246,10 +247,10 @@ public abstract class ExternalableTreeSet<T extends WritableComparable<T> & Seri
 
     @Override
     public void write(DataOutput out) throws IOException {
-        boolean pathsUnmodified = !writeEntireBody && !isLoaded && path != null && readFromLocal == writeToLocal;
+        boolean pathsUnmodified = !writeEntireBody && !isChanged && path != null && readFromLocal == writeToLocal;
         boolean wholeBodyInStream = writeEntireBody || inMemorySet.size() < countLimit;
         out.writeBoolean(wholeBodyInStream);
-        
+
         if (pathsUnmodified) {
             out.writeBoolean(writeToLocal);
             out.writeUTF(path.toString());
@@ -288,25 +289,25 @@ public abstract class ExternalableTreeSet<T extends WritableComparable<T> & Seri
         private Path hdfsWorkPath;
         private Path localWorkPath;
         private Configuration conf;
-        private HashMap<Path, OutputStream> allocatedHdfsPath;
-        private HashMap<Path, OutputStream> allocatedLocalPath;
+        private HashSet<Path> allocatedHdfsPath;
+        private HashSet<Path> allocatedLocalPath;
 
         public FileManager(Configuration conf, Path hdfsWorkingPath) throws IOException {
             hfs = FileSystem.get(conf);
             lfs = FileSystem.getLocal(conf);
             hdfsWorkPath = hdfsWorkingPath;
             localWorkPath = new Path(BspUtils.TMP_DIR);
-            allocatedHdfsPath = new HashMap<Path, OutputStream>();
-            allocatedLocalPath = new HashMap<Path, OutputStream>();
+            allocatedHdfsPath = new HashSet<Path>();
+            allocatedLocalPath = new HashSet<Path>();
             this.conf = conf;
         }
 
         public void deleteAll() throws IOException {
-            for (Path path : allocatedHdfsPath.keySet()) {
+            for (Path path : allocatedHdfsPath) {
                 deleteFile(path, false);
             }
             allocatedHdfsPath.clear();
-            for (Path path : allocatedLocalPath.keySet()) {
+            for (Path path : allocatedLocalPath) {
                 deleteFile(path, true);
             }
             allocatedLocalPath.clear();
@@ -324,19 +325,21 @@ public abstract class ExternalableTreeSet<T extends WritableComparable<T> & Seri
             }
         }
 
-        private static synchronized Path createOneFile(HashMap<Path, OutputStream> validation, FileSystem fs,
-                Path workPath) throws IOException {
+        private static synchronized Path createOneFile(HashSet<Path> validation, FileSystem fs, Path workPath)
+                throws IOException {
             Path path;
             do {
                 path = new Path(workPath, "ExternalableTreeSet" + UUID.randomUUID());
             } while (fs.exists(path));
-            validation.put(path, fs.create(path, (short) 1));
+            FSDataOutputStream os = fs.create(path, (short) 1);
+            os.close();
+            validation.add(path);
             return path;
         }
 
-        private static synchronized void deleteOneFile(Path path, final HashMap<Path, OutputStream> validation,
-                FileSystem fs) throws IOException {
-            if (path != null && validation.containsKey(path)) {
+        private static synchronized void deleteOneFile(Path path, final HashSet<Path> validation, FileSystem fs)
+                throws IOException {
+            if (path != null && validation.contains(path)) {
                 fs.delete(path, true);
             }
         }
@@ -349,19 +352,19 @@ public abstract class ExternalableTreeSet<T extends WritableComparable<T> & Seri
             }
         }
 
-        private static OutputStream getOutputStream(Path path, HashMap<Path, OutputStream> validation)
+        private static OutputStream getOutputStream(Path path, HashSet<Path> validation, FileSystem fs)
                 throws IOException {
-            if (!validation.containsKey(path)) {
+            if (!validation.contains(path)) {
                 throw new IOException("File not registered:" + path);
             }
-            return validation.get(path);
+            return fs.create(path, (short) 1);
         }
 
         public OutputStream getOutputStream(Path path, boolean local) throws IOException {
             if (local) {
-                return getOutputStream(path, allocatedLocalPath);
+                return getOutputStream(path, allocatedLocalPath, lfs);
             } else {
-                return getOutputStream(path, allocatedHdfsPath);
+                return getOutputStream(path, allocatedHdfsPath, hfs);
             }
         }
 


### PR DESCRIPTION
@jakebiesinger @anbangx 
This PR is to creat a DataOutputStream each time, instead of using the old one. This might be the problems of the `Stream Closed` exceptions. And this PR is based on the `wbiesing/readheadset-uses-static-configuration` branch. 
