### PR TITLE
Implement simple edge prune

### DIFF
--- a/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
+++ b/genomix/genomix-data/src/main/java/edu/uci/ics/genomix/data/config/GenomixJobConf.java
@@ -215,6 +215,7 @@ public class GenomixJobConf extends JobConf {
         RAY_SCAFFOLD,
         RAY_SCAFFOLD_FORWARD,
         RAY_SCAFFOLD_REVERSE,
+        RAY_SCAFFOLD_PRUNE,
         SPLIT_REPEAT,
         DUMP_FASTA,
         CHECK_SYMMETRY,

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -503,14 +503,24 @@ public class GenomixDriver {
                     LOG.info("Starting job " + pregelixJobs.get(i).getJobName());
                     GenomixJobConf.tick("pregelix-job");
 
-                    pregelixDriver.runJob(pregelixJobs.get(i), masterIP, pregelixPort);
+                    if (i < pregelixJobs.size() - 1 && 
+                    		pregelixJobs.get(i).getJobName().equals(RayVertex.class.getSimpleName()) && 
+                    		pregelixJobs.get(i + 1).getJobName().equals(PruneVertex.class.getSimpleName())) {
+                    	// prune vertex cannot save to disk :(
+                    	pregelixDriver.runJobs(Arrays.asList(pregelixJobs.get(i), pregelixJobs.get(i + 1)), masterIP, pregelixPort);
+                    	LOG.info("Finished job " + pregelixJobs.get(i).getJobName() + " in "
+                                + GenomixJobConf.tock("pregelix-job") + "ms");
+                    	i++;
+                    } else {
+                    	pregelixDriver.runJob(pregelixJobs.get(i), masterIP, pregelixPort);
+                    }
 
                     LOG.info("Finished job " + pregelixJobs.get(i).getJobName() + " in "
                             + GenomixJobConf.tock("pregelix-job") + "ms");
                 }
                 LOG.info("Finished job series in " + GenomixJobConf.tock("pregelix-runJob-one-by-one"));
             } else {
-                LOG.info("Starting pregelix job series (not saving intermediate results...");
+                LOG.info("Starting pregelix job series (not saving intermediate results...)");
                 GenomixJobConf.tick("pregelix-runJobs");
 
                 pregelixDriver.runJobs(pregelixJobs, masterIP, pregelixPort);

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -741,11 +741,10 @@ public class GenomixDriver {
             }
         } catch (CmdLineException ex) {
             System.err.println("Usage: bin/genomix [options]\n");
-            ex.getParser().setUsageWidth(80);
+            ex.getParser().setUsageWidth(100);
             ex.getParser().printUsage(System.err);
             System.err.println("\nExample:");
-            System.err
-                    .println("\tbin/genomix -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput /path/to/readfiledir/\n");
+            System.err.println("\tbin/genomix -kmerLength 55 -pipelineOrder BUILD_HYRACKS,MERGE,TIP_REMOVE,MERGE,BUBBLE,MERGE -localInput /path/to/readfiledir/\n");
             System.err.println(ex.getMessage());
 
             return;
@@ -763,5 +762,4 @@ public class GenomixDriver {
             }
         }
     }
-
 }

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -571,7 +571,9 @@ public class GenomixDriver {
                 }
                 // replace
                 allPatterns.add(i, Patterns.RAY_SCAFFOLD_FORWARD);
-                allPatterns.add(i + 1, Patterns.RAY_SCAFFOLD_PRUNE);
+                if (RayVertex.DELAY_PRUNE) {
+                	allPatterns.add(i + 1, Patterns.RAY_SCAFFOLD_PRUNE);
+                }
                 //allPatterns.add(i + 1, Patterns.MERGE);
                 //allPatterns.add(i + 1, Patterns.STATS);
                // allPatterns.add(i, Patterns.RAY_SCAFFOLD_REVERSE);

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -571,7 +571,7 @@ public class GenomixDriver {
                 }
                 // replace
                 allPatterns.add(i, Patterns.RAY_SCAFFOLD_FORWARD);
-                allPatterns.add(i, Patterns.RAY_SCAFFOLD_PRUNE);
+                allPatterns.add(i + 1, Patterns.RAY_SCAFFOLD_PRUNE);
                 //allPatterns.add(i + 1, Patterns.MERGE);
                 //allPatterns.add(i + 1, Patterns.STATS);
                // allPatterns.add(i, Patterns.RAY_SCAFFOLD_REVERSE);

--- a/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
+++ b/genomix/genomix-driver/src/main/java/edu/uci/ics/genomix/driver/GenomixDriver.java
@@ -70,6 +70,7 @@ import edu.uci.ics.genomix.pregelix.operator.extractsubgraph.ExtractSubgraphVert
 import edu.uci.ics.genomix.pregelix.operator.pathmerge.P1ForPathMergeVertex;
 import edu.uci.ics.genomix.pregelix.operator.pathmerge.P4ForPathMergeVertex;
 import edu.uci.ics.genomix.pregelix.operator.removelowcoverage.RemoveLowCoverageVertex;
+import edu.uci.ics.genomix.pregelix.operator.scaffolding2.PruneVertex;
 //import edu.uci.ics.genomix.pregelix.operator.removelowcoverage.ShiftLowCoverageReadSetVertex;
 import edu.uci.ics.genomix.pregelix.operator.scaffolding2.RayVertex;
 import edu.uci.ics.genomix.pregelix.operator.simplebubblemerge.SimpleBubbleMergeVertex;
@@ -314,6 +315,9 @@ public class GenomixDriver {
                     pregelixJobs.add(RayVertex.getConfiguredJob(conf, RayVertex.class));
                 }
                 break;
+            case RAY_SCAFFOLD_PRUNE:
+            	pregelixJobs.add(PruneVertex.getConfiguredJob(conf, PruneVertex.class));
+            	break;
             case DUMP_FASTA:
                 flushPendingJobs(conf);
                 curOutput = prevOutput + "-DUMP_FASTA";
@@ -567,6 +571,7 @@ public class GenomixDriver {
                 }
                 // replace
                 allPatterns.add(i, Patterns.RAY_SCAFFOLD_FORWARD);
+                allPatterns.add(i, Patterns.RAY_SCAFFOLD_PRUNE);
                 //allPatterns.add(i + 1, Patterns.MERGE);
                 //allPatterns.add(i + 1, Patterns.STATS);
                // allPatterns.add(i, Patterns.RAY_SCAFFOLD_REVERSE);

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/PruneVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/PruneVertex.java
@@ -61,7 +61,7 @@ public class PruneVertex extends DeBruijnGraphCleanVertex<RayValue, MessageWrita
 				neighborEdgesToKeep.add(new SimpleEntry<>(EDGETYPE.fromByte(msg.getFlag()), new VKmer(msg.getSourceVertexId())));
 			}
 			Set<Entry<EDGETYPE, VKmer>> prunedEdges = pruneUnsavedEdges(neighborEdgesToKeep);
-			if (prunedEdges.size() > 0) {
+			if (verbose && prunedEdges.size() > 0) {
 				LOG.info("Pruned " + prunedEdges);
 			}
 			for (Entry<EDGETYPE, VKmer> entry : prunedEdges) {
@@ -69,14 +69,18 @@ public class PruneVertex extends DeBruijnGraphCleanVertex<RayValue, MessageWrita
 				outgoingMsg.setSourceVertexId(getVertexId());
 				outgoingMsg.setFlag(entry.getKey().mirror().get());
 				sendMsg(entry.getValue(), outgoingMsg);
-				LOG.info("Telling " + entry.getValue() + " in my " + entry.getKey() + " to prune me (" + getVertexId() + ").");
+				if (verbose) {
+					LOG.info("Telling " + entry.getValue() + " in my " + entry.getKey() + " to prune me (" + getVertexId() + ").");	
+				}
 			}
 			voteToHalt();
 		} else {
 			// Respond to a prune edge request.
 			while (msgIterator.hasNext()) {
 				msg = msgIterator.next();
-				LOG.info("in " + getVertexId() + ", request to prune back edge: " + msg.getSourceVertexId() + " in my " + EDGETYPE.fromByte(msg.getFlag()));
+				if (verbose) {
+					LOG.info("in " + getVertexId() + ", request to prune back edge: " + msg.getSourceVertexId() + " in my " + EDGETYPE.fromByte(msg.getFlag()));
+				}
 				vertex.getEdges(EDGETYPE.fromByte(msg.getFlag())).remove(msg.getSourceVertexId(), true);
 			}
 			voteToHalt();

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/PruneVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/PruneVertex.java
@@ -1,0 +1,93 @@
+package edu.uci.ics.genomix.pregelix.operator.scaffolding2;
+
+import java.io.IOException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+
+import edu.uci.ics.genomix.data.config.GenomixJobConf;
+import edu.uci.ics.genomix.data.types.EDGETYPE;
+import edu.uci.ics.genomix.data.types.VKmer;
+import edu.uci.ics.genomix.pregelix.base.DeBruijnGraphCleanVertex;
+import edu.uci.ics.genomix.pregelix.base.MessageWritable;
+import edu.uci.ics.genomix.pregelix.base.VertexValueWritable;
+import edu.uci.ics.pregelix.api.job.PregelixJob;
+
+public class PruneVertex extends DeBruijnGraphCleanVertex<RayValue, MessageWritable> {
+	
+	@Override
+	public void configure(Configuration conf) {
+		// Unlike every other job, we DON'T want to clear state from the previous job.
+	}
+	
+	public static PregelixJob getConfiguredJob(
+            GenomixJobConf conf,
+            Class<? extends DeBruijnGraphCleanVertex<? extends VertexValueWritable, ? extends MessageWritable>> vertexClass)
+            throws IOException {
+        PregelixJob job = DeBruijnGraphCleanVertex.getConfiguredJob(conf, vertexClass);
+        job.setVertexInputFormatClass(NodeToRayVertexInputFormat.class);
+        job.setVertexOutputFormatClass(RayVertexToNodeOutputFormat.class);
+        return job;
+    }
+	
+	@Override
+	public void compute(Iterator<MessageWritable> msgIterator) throws Exception {
+		// Nodes visited by a walk have some subset of their edges removed
+		if (getSuperstep() == 1) {
+			Set<Entry<EDGETYPE, VKmer>> prunedEdges = pruneUnsavedEdges();
+			for (Entry<EDGETYPE, VKmer> entry : prunedEdges) {
+				outgoingMsg.reset();
+				outgoingMsg.setSourceVertexId(getVertexId());
+				outgoingMsg.setFlag(entry.getKey().mirror().get());
+				sendMsg(entry.getValue(), outgoingMsg);
+			}
+		} else {
+			// Respond to a prune edge request.
+			MessageWritable msg;
+			RayValue vertex = getVertexValue();
+			while (msgIterator.hasNext()) {
+				msg = msgIterator.next();
+				vertex.getEdges(EDGETYPE.fromByte(msg.getFlag())).remove(msg.getSourceVertexId());
+			}
+		}
+		voteToHalt();
+	}
+
+	private Set<Entry<EDGETYPE, VKmer>> pruneUnsavedEdges() {
+		RayValue vertex = getVertexValue();
+		VKmer kmer;
+		SimpleEntry<EDGETYPE, VKmer> entry;
+		HashSet<Entry<EDGETYPE, VKmer>> prunedEdges = new HashSet<>();
+		if (RayVertex.REMOVE_OTHER_OUTGOING) {
+			for (EDGETYPE et : EDGETYPE.values) {
+				Iterator<VKmer> edges = vertex.getEdges(et).iterator();
+				while(edges.hasNext()) {
+					kmer = edges.next();
+					entry = new SimpleEntry<>(et, kmer);
+					if (!vertex.getOutgoingEdgesToKeep().contains(entry)) {
+						prunedEdges.add(entry);
+						edges.remove();
+					}
+				}
+			}
+		}
+		if (RayVertex.REMOVE_OTHER_INCOMING) {
+			for (EDGETYPE et : EDGETYPE.values) {
+				Iterator<VKmer> edges = vertex.getEdges(et).iterator();
+				while(edges.hasNext()) {
+					kmer = edges.next();
+					entry = new SimpleEntry<>(et, kmer);
+					if (!vertex.getIncomingEdgesToKeep().contains(entry)) {
+						prunedEdges.add(entry);
+						edges.remove();
+					}
+				}
+			}
+		}
+		return prunedEdges;
+	}
+}

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayValue.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayValue.java
@@ -35,8 +35,8 @@ public class RayValue extends VertexValueWritable {
         public static final short STOP_SEARCH = 0b1 << 4;
         public static final short PENDING_CANDIDATE_BRANCHES = 1 << 5;
         public static final short  CANDIDATE_MSGS_MAP = 1 << 6;
-		public static final short FORWARD_EDGES_TO_KEEP = 1 << 7;
-		public static final short REVERSE_EDGES_TO_KEEP = 1 << 8;
+		public static final short OUTGOING_EDGES_TO_KEEP = 1 << 7;
+		public static final short INCOMING_EDGES_TO_KEEP = 1 << 8;
     }
 
     @Override
@@ -117,22 +117,22 @@ public class RayValue extends VertexValueWritable {
             }
         }
         
-        if ((state & FIELDS.FORWARD_EDGES_TO_KEEP) != 0) {
+        if ((state & FIELDS.OUTGOING_EDGES_TO_KEEP) != 0) {
         	int count = in.readInt();
         	for (int i = 0; i < count; i++) {
         		EDGETYPE et = EDGETYPE.fromByte(in.readByte());
         		VKmer kmer = new VKmer();
         		kmer.readFields(in);
-        		getOutgoingEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
+        		getOutgoingEdgesToKeep().add(new SimpleEntry<>(et, kmer));
         	}
         }
-        if ((state & FIELDS.REVERSE_EDGES_TO_KEEP) != 0) {
+        if ((state & FIELDS.INCOMING_EDGES_TO_KEEP) != 0) {
         	int count = in.readInt();
         	for (int i = 0; i < count; i++) {
         		EDGETYPE et = EDGETYPE.fromByte(in.readByte());
         		VKmer kmer = new VKmer();
         		kmer.readFields(in);
-        		getIncomingEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
+        		getIncomingEdgesToKeep().add(new SimpleEntry<>(et, kmer));
         	}
         }
     }
@@ -161,10 +161,10 @@ public class RayValue extends VertexValueWritable {
             state |= FIELDS.CANDIDATE_MSGS_MAP;
         }
         if (outgoingEdgesToKeep != null && outgoingEdgesToKeep.size() > 0) {
-            state |= FIELDS.FORWARD_EDGES_TO_KEEP;
+            state |= FIELDS.OUTGOING_EDGES_TO_KEEP;
         }
         if (incomingEdgesToKeep != null && incomingEdgesToKeep.size() > 0) {
-            state |= FIELDS.REVERSE_EDGES_TO_KEEP;
+            state |= FIELDS.INCOMING_EDGES_TO_KEEP;
         }
         super.write(out);
         

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayValue.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayValue.java
@@ -24,8 +24,8 @@ public class RayValue extends VertexValueWritable {
     HashMap<VKmer, Boolean> stopSearch = null;
     HashMap<VKmer, Integer> pendingCandidateBranchesMap = null;
     HashMap<VKmer, ArrayList<RayMessage>> candidateMsgsMap =  null;
-    ArrayList<Entry<EDGETYPE, VKmer>> forwardEdgesToKeep  =  null;
-    ArrayList<Entry<EDGETYPE, VKmer>> reverseEdgesToKeep  =  null;
+    ArrayList<Entry<EDGETYPE, VKmer>> outgoingEdgesToKeep  =  null;
+    ArrayList<Entry<EDGETYPE, VKmer>> incomingEdgesToKeep  =  null;
     //ArrayList<RayMessage> candidateMsgs = null;
 
     protected static class FIELDS {
@@ -123,7 +123,7 @@ public class RayValue extends VertexValueWritable {
         		EDGETYPE et = EDGETYPE.fromByte(in.readByte());
         		VKmer kmer = new VKmer();
         		kmer.readFields(in);
-        		getForwardEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
+        		getOutgoingEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
         	}
         }
         if ((state & FIELDS.REVERSE_EDGES_TO_KEEP) != 0) {
@@ -132,7 +132,7 @@ public class RayValue extends VertexValueWritable {
         		EDGETYPE et = EDGETYPE.fromByte(in.readByte());
         		VKmer kmer = new VKmer();
         		kmer.readFields(in);
-        		getReverseEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
+        		getIncomingEdgesToKeep().add(new SimpleEntry<EDGETYPE, VKmer>(et, kmer));
         	}
         }
     }
@@ -160,10 +160,10 @@ public class RayValue extends VertexValueWritable {
         if (candidateMsgsMap != null && candidateMsgsMap.size() > 0) {
             state |= FIELDS.CANDIDATE_MSGS_MAP;
         }
-        if (forwardEdgesToKeep != null && forwardEdgesToKeep.size() > 0) {
+        if (outgoingEdgesToKeep != null && outgoingEdgesToKeep.size() > 0) {
             state |= FIELDS.FORWARD_EDGES_TO_KEEP;
         }
-        if (reverseEdgesToKeep != null && reverseEdgesToKeep.size() > 0) {
+        if (incomingEdgesToKeep != null && incomingEdgesToKeep.size() > 0) {
             state |= FIELDS.REVERSE_EDGES_TO_KEEP;
         }
         super.write(out);
@@ -220,16 +220,16 @@ public class RayValue extends VertexValueWritable {
                 }
     		}
         }
-        if (forwardEdgesToKeep != null && forwardEdgesToKeep.size() > 0) {
-            out.writeInt(forwardEdgesToKeep.size());
-            for (Entry<EDGETYPE, VKmer> entry : forwardEdgesToKeep){
+        if (outgoingEdgesToKeep != null && outgoingEdgesToKeep.size() > 0) {
+            out.writeInt(outgoingEdgesToKeep.size());
+            for (Entry<EDGETYPE, VKmer> entry : outgoingEdgesToKeep){
             	out.writeByte(entry.getKey().get());
             	entry.getValue().write(out);
     		}
         }
-        if (reverseEdgesToKeep != null && reverseEdgesToKeep.size() > 0) {
-            out.writeInt(reverseEdgesToKeep.size());
-            for (Entry<EDGETYPE, VKmer> entry : reverseEdgesToKeep){
+        if (incomingEdgesToKeep != null && incomingEdgesToKeep.size() > 0) {
+            out.writeInt(incomingEdgesToKeep.size());
+            for (Entry<EDGETYPE, VKmer> entry : incomingEdgesToKeep){
             	out.writeByte(entry.getKey().get());
             	entry.getValue().write(out);
     		}
@@ -245,8 +245,8 @@ public class RayValue extends VertexValueWritable {
         visitedList = null;
         pendingCandidateBranchesMap = null;
         candidateMsgsMap = null;
-        forwardEdgesToKeep = null;
-        reverseEdgesToKeep = null;
+        outgoingEdgesToKeep = null;
+        incomingEdgesToKeep = null;
     }
 
     /**
@@ -351,26 +351,26 @@ public class RayValue extends VertexValueWritable {
     	this.flippedFromInitialDirection= flippedFromInitialDirection;
     }
     
-    public ArrayList<Entry<EDGETYPE, VKmer>> getForwardEdgesToKeep() {
-    	if (forwardEdgesToKeep == null) {
-    		forwardEdgesToKeep = new ArrayList<>();
+    public ArrayList<Entry<EDGETYPE, VKmer>> getOutgoingEdgesToKeep() {
+    	if (outgoingEdgesToKeep == null) {
+    		outgoingEdgesToKeep = new ArrayList<>();
     	}
-		return forwardEdgesToKeep;
+		return outgoingEdgesToKeep;
 	}
     
-    public void setForwardEdgesToKeep(ArrayList<Entry<EDGETYPE, VKmer>> forwardEdgesToKeep) {
-    	this.forwardEdgesToKeep = forwardEdgesToKeep;
+    public void setForwardEdgesToKeep(ArrayList<Entry<EDGETYPE, VKmer>> outgoingEdgesToKeep) {
+    	this.outgoingEdgesToKeep = outgoingEdgesToKeep;
 	}
     
-    public ArrayList<Entry<EDGETYPE, VKmer>> getReverseEdgesToKeep() {
-    	if (reverseEdgesToKeep == null) {
-    		reverseEdgesToKeep = new ArrayList<>();
+    public ArrayList<Entry<EDGETYPE, VKmer>> getIncomingEdgesToKeep() {
+    	if (incomingEdgesToKeep == null) {
+    		incomingEdgesToKeep = new ArrayList<>();
     	}
-		return reverseEdgesToKeep;
+		return incomingEdgesToKeep;
 	}
     
-    public void setReverseEdgesToKeep(ArrayList<Entry<EDGETYPE, VKmer>> reverseEdgesToKeep) {
-    	this.reverseEdgesToKeep = reverseEdgesToKeep;
+    public void setIncomingEdgesToKeep(ArrayList<Entry<EDGETYPE, VKmer>> incomingEdgesToKeep) {
+    	this.incomingEdgesToKeep = incomingEdgesToKeep;
 	}
     
 }

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
@@ -136,9 +136,10 @@ public class RayVertex extends DeBruijnGraphCleanVertex<RayValue, RayMessage> {
                         + ", score: " + getVertexValue().calculateSeedScore());
             }
         }
-        scaffold(msgIterator);
+        if (getSuperstep() < maxIteration) {
+        	scaffold(msgIterator);
+        }
         voteToHalt();
-        
     }
 
     /**

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
@@ -57,8 +57,8 @@ public class RayVertex extends DeBruijnGraphCleanVertex<RayValue, RayMessage> {
     public static final boolean REMOVE_OTHER_OUTGOING = true; // whether to remove other outgoing branches when a dominant edge is chosen
     public static final boolean REMOVE_OTHER_INCOMING = false; // whether to remove other incoming branches when a dominant edge is chosen
     public static final boolean CANDIDATES_SCORE_WALK = false; // whether to have the candidates score the walk
-    private static final boolean EXPAND_CANDIDATE_BRANCHES = false; // whether to get kmer from all possible candidate branches
-    private static final boolean DELAY_PRUNE = true; // Whether we should perform the prune as a separate job, after all the walks have completed their march. 
+    public static final boolean EXPAND_CANDIDATE_BRANCHES = false; // whether to get kmer from all possible candidate branches
+    public static final boolean DELAY_PRUNE = true; // Whether we should perform the prune as a separate job, after all the walks have completed their march. 
     PrintWriter writer;
     PrintWriter log;
     
@@ -429,11 +429,7 @@ public class RayVertex extends DeBruijnGraphCleanVertex<RayValue, RayMessage> {
         DIR prevDir = msg.getEdgeTypeBackToFrontier().dir();
 
         if (DELAY_PRUNE) {
-			if (prevDir == DIR.FORWARD) {
-				vertex.getForwardEdgesToKeep().add(new SimpleEntry<>(msg.getEdgeTypeBackToFrontier(), lastId));
-			} else {
-				vertex.getReverseEdgesToKeep().add(new SimpleEntry<>(msg.getEdgeTypeBackToFrontier(), lastId));
-			}
+			vertex.getIncomingEdgesToKeep().add(new SimpleEntry<>(msg.getEdgeTypeBackToFrontier(), lastId));
 		} else {
 	        for (EDGETYPE et : prevDir.edgeTypes()) {
 	            Iterator<VKmer> it = vertex.getEdges(et).iterator();
@@ -1152,11 +1148,7 @@ public class RayVertex extends DeBruijnGraphCleanVertex<RayValue, RayMessage> {
         	if (dominantEdgeFound) {
         		// if a dominant edge is found, all the others must be removed.
         		if (DELAY_PRUNE) {
-        			if (dominantEdgeType.dir() == DIR.FORWARD) {
-        				vertex.getForwardEdgesToKeep().add(new SimpleEntry<>(dominantEdgeType, dominantKmer));
-        			} else {
-        				vertex.getReverseEdgesToKeep().add(new SimpleEntry<>(dominantEdgeType, dominantKmer));
-        			}
+        			vertex.getOutgoingEdgesToKeep().add(new SimpleEntry<>(dominantEdgeType, dominantKmer));
         		} else if (REMOVE_OTHER_OUTGOING) {
         			for (EDGETYPE et : dominantEdgeType.dir().edgeTypes()) {
         				for (VKmer kmer : vertex.getEdges(et)) {

--- a/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
+++ b/genomix/genomix-pregelix/src/main/java/edu/uci/ics/genomix/pregelix/operator/scaffolding2/RayVertex.java
@@ -55,7 +55,7 @@ public class RayVertex extends DeBruijnGraphCleanVertex<RayValue, RayMessage> {
     private static int MAX_DISTANCE; // the max(readlengths, outerdistances)
 
     public static final boolean REMOVE_OTHER_OUTGOING = true; // whether to remove other outgoing branches when a dominant edge is chosen
-    public static final boolean REMOVE_OTHER_INCOMING = false; // whether to remove other incoming branches when a dominant edge is chosen
+    public static final boolean REMOVE_OTHER_INCOMING = true; // whether to remove other incoming branches when a dominant edge is chosen
     public static final boolean CANDIDATES_SCORE_WALK = false; // whether to have the candidates score the walk
     public static final boolean EXPAND_CANDIDATE_BRANCHES = false; // whether to get kmer from all possible candidate branches
     public static final boolean DELAY_PRUNE = true; // Whether we should perform the prune as a separate job, after all the walks have completed their march. 


### PR DESCRIPTION
@Elmira88 
Implements the simple delayed edge prune for scaffolding and adds it as another job after the FORWARD job.

Compared to the previous PR, I realized that the tracking needs to be incoming/outgoing, not forward/reverse.  Hopefully you didn't spend too much time there.

The delayed removal _should be_ fully compatible with REMOVE_OTHER_INCOMING and REMOVE_OTHER_OUTGOING.
